### PR TITLE
fix: Cache file writes are now atomic - prevent corrupt entries from interrupted or concurrent writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Fixed
 - Use EphemeralKeySet when loading HTTPS certificate to fix Docker container startup failure
 - Re-enabled Native AOT compilation and trimming by adding SuppressTrimAnalysisWarnings to suppress third-party IL2104 warnings blocking dotnet publish
+- Cache file writes are now atomic - use write-to-temp-then-rename to prevent corrupt cache entries from interrupted or concurrent writes
 ### Changed
 - Dependencies - Updated Credfeto.Version.Information.Generator to 1.0.125.1199
 - Dependencies - Updated FunFair.CodeAnalysis to 7.2.0.1978

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemJsonStorageTests.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemJsonStorageTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers.Text;
 using System.IO;
 using System.IO.Compression;
@@ -299,6 +299,102 @@ public sealed class FileSystemJsonStorageTests : LoggingFolderCleanupTestBase
         };
 
         _ = new FileSystemJsonStorage(Options.Create(config), this.GetTypedLogger<FileSystemJsonStorage>());
+    }
+
+    [Fact]
+    public async Task ConcurrentSaveAsync_FileContainsOneOfTheWrittenValuesAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+        Uri requestUri = new("https://api.nuget.org/v3/concurrent.json");
+
+        const string JSON_CONTENT_1 = """{"version":"1.0.0"}""";
+        const string JSON_CONTENT_2 = """{"version":"2.0.0"}""";
+
+        JsonMetadata metadata1 = new(
+            Etag: "\"etag1\"",
+            ContentLength: JSON_CONTENT_1.Length,
+            ContentType: "application/json"
+        );
+        JsonMetadata metadata2 = new(
+            Etag: "\"etag2\"",
+            ContentLength: JSON_CONTENT_2.Length,
+            ContentType: "application/json"
+        );
+
+        await Task.WhenAll(
+            this._jsonStorage.SaveAsync(
+                    requestUri: requestUri,
+                    metadata: metadata1,
+                    jsonContent: JSON_CONTENT_1,
+                    cancellationToken: cancellationToken
+                )
+                .AsTask(),
+            this._jsonStorage.SaveAsync(
+                    requestUri: requestUri,
+                    metadata: metadata2,
+                    jsonContent: JSON_CONTENT_2,
+                    cancellationToken: cancellationToken
+                )
+                .AsTask()
+        );
+
+        (JsonMetadata metadata, string content)? result = await this._jsonStorage.LoadAsync(
+            requestUri: requestUri,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.NotNull(result);
+        Assert.True(
+            condition: string.Equals(a: result.Value.content, b: JSON_CONTENT_1, StringComparison.Ordinal)
+                || string.Equals(a: result.Value.content, b: JSON_CONTENT_2, StringComparison.Ordinal),
+            userMessage: "Concurrent writes must not produce a corrupt mix of both payloads"
+        );
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenCancelledBeforeWrite_ExistingFileIsPreservedAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+        Uri requestUri = new("https://api.nuget.org/v3/preserve.json");
+
+        const string ORIGINAL_CONTENT = """{"version":"1.0.0"}""";
+        JsonMetadata originalMetadata = new(
+            Etag: "\"original\"",
+            ContentLength: ORIGINAL_CONTENT.Length,
+            ContentType: "application/json"
+        );
+
+        await this._jsonStorage.SaveAsync(
+            requestUri: requestUri,
+            metadata: originalMetadata,
+            jsonContent: ORIGINAL_CONTENT,
+            cancellationToken: cancellationToken
+        );
+
+        using CancellationTokenSource cts = new();
+        await cts.CancelAsync();
+
+        const string NEW_CONTENT = """{"version":"2.0.0"}""";
+        JsonMetadata newMetadata = new(
+            Etag: "\"new\"",
+            ContentLength: NEW_CONTENT.Length,
+            ContentType: "application/json"
+        );
+
+        await this._jsonStorage.SaveAsync(
+            requestUri: requestUri,
+            metadata: newMetadata,
+            jsonContent: NEW_CONTENT,
+            cancellationToken: cts.Token
+        );
+
+        (JsonMetadata metadata, string content)? result = await this._jsonStorage.LoadAsync(
+            requestUri: requestUri,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: ORIGINAL_CONTENT, actual: result.Value.content);
     }
 
     private static async ValueTask<string> CompressToBase64UrlAsync(string source, CancellationToken cancellationToken)

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemPackageStorageTests.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemPackageStorageTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Credfeto.Nuget.Proxy.Models.Config;
@@ -187,5 +188,71 @@ public sealed class FileSystemPackageStorageTests : LoggingFolderCleanupTestBase
             condition: Directory.Exists(newSubDir),
             userMessage: "Expected sub-directory to be created by constructor"
         );
+    }
+
+    [Fact]
+    public async Task ConcurrentSaveFileAsync_FileContainsOneOfTheWrittenValuesAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        byte[] content1 = [1, 2, 3, 4, 5];
+        byte[] content2 = [6, 7, 8, 9, 10];
+
+        await Task.WhenAll(
+            this._packageStorage.SaveFileAsync(
+                    sourcePath: "concurrent.nupkg",
+                    buffer: content1,
+                    cancellationToken: cancellationToken
+                )
+                .AsTask(),
+            this._packageStorage.SaveFileAsync(
+                    sourcePath: "concurrent.nupkg",
+                    buffer: content2,
+                    cancellationToken: cancellationToken
+                )
+                .AsTask()
+        );
+
+        byte[]? result = await this._packageStorage.ReadFileAsync(
+            sourcePath: "concurrent.nupkg",
+            cancellationToken: cancellationToken
+        );
+
+        Assert.NotNull(result);
+        Assert.True(
+            condition: result.SequenceEqual(content1) || result.SequenceEqual(content2),
+            userMessage: "Concurrent writes must not produce a corrupt mix of both payloads"
+        );
+    }
+
+    [Fact]
+    public async Task SaveFileAsync_WhenCancelledBeforeWrite_ExistingFileIsPreservedAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        byte[] original = [1, 2, 3, 4, 5];
+
+        await this._packageStorage.SaveFileAsync(
+            sourcePath: "preserve.nupkg",
+            buffer: original,
+            cancellationToken: cancellationToken
+        );
+
+        using CancellationTokenSource cts = new();
+        await cts.CancelAsync();
+
+        await this._packageStorage.SaveFileAsync(
+            sourcePath: "preserve.nupkg",
+            buffer: [6, 7, 8, 9, 10],
+            cancellationToken: cts.Token
+        );
+
+        byte[]? result = await this._packageStorage.ReadFileAsync(
+            sourcePath: "preserve.nupkg",
+            cancellationToken: cancellationToken
+        );
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: original, actual: result);
     }
 }

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
@@ -41,6 +41,8 @@ public sealed class FileSystemJsonStorage : IJsonStorage
     {
         (string jsonPath, string dir) = this.BuildJsonPath(sourceHost: requestUri.Host, path: requestUri.AbsolutePath);
 
+        string? tempPath = null;
+
         try
         {
             this.EnsureDirectoryExists(dir);
@@ -54,7 +56,9 @@ public sealed class FileSystemJsonStorage : IJsonStorage
                 content: compressed
             );
 
-            await using (Stream stream = File.OpenWrite(jsonPath))
+            tempPath = Path.Combine(dir, Path.GetRandomFileName());
+
+            await using (Stream stream = File.OpenWrite(tempPath))
             {
                 await JsonSerializer.SerializeAsync(
                     utf8Json: stream,
@@ -63,10 +67,27 @@ public sealed class FileSystemJsonStorage : IJsonStorage
                     cancellationToken: cancellationToken
                 );
             }
+
+            File.Move(sourceFileName: tempPath, destFileName: jsonPath, overwrite: true);
+            tempPath = null;
         }
         catch (Exception exception)
         {
             this._logger.SaveFailed(filename: jsonPath, message: exception.Message, exception: exception);
+        }
+        finally
+        {
+            if (tempPath is not null)
+            {
+                try
+                {
+                    File.Delete(tempPath);
+                }
+                catch (Exception exception)
+                {
+                    Debug.WriteLine($"Failed to delete temp file {tempPath}: {exception.Message}");
+                }
+            }
         }
     }
 
@@ -79,12 +100,15 @@ public sealed class FileSystemJsonStorage : IJsonStorage
 
         try
         {
-            if (!File.Exists(jsonPath))
-            {
-                return null;
-            }
-
             return await ReadFromFileAsync(jsonPath: jsonPath, cancellationToken: cancellationToken);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return null;
         }
         catch (UnauthorizedAccessException exception)
         {

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
@@ -57,7 +57,7 @@ public sealed class FileSystemJsonStorage : IJsonStorage
 
             tempPath = Path.Combine(dir, Path.GetRandomFileName());
 
-            await using (Stream stream = File.OpenWrite(tempPath))
+            await using (Stream stream = File.Create(tempPath))
             {
                 await JsonSerializer.SerializeAsync(
                     utf8Json: stream,

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Buffers.Text;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
@@ -85,7 +84,11 @@ public sealed class FileSystemJsonStorage : IJsonStorage
                 }
                 catch (Exception exception)
                 {
-                    Debug.WriteLine($"Failed to delete temp file {tempPath}: {exception.Message}");
+                    this._logger.TempFileDeletionFailed(
+                        filename: tempPath,
+                        message: exception.Message,
+                        exception: exception
+                    );
                 }
             }
         }
@@ -122,7 +125,7 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         }
         catch (Exception exception)
         {
-            DeleteCorrupt(jsonPath);
+            this.DeleteCorrupt(jsonPath);
             this._logger.FailedToReadFileFromCache(
                 filename: jsonPath,
                 message: exception.Message,
@@ -157,7 +160,7 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         return string.IsNullOrWhiteSpace(content) ? null : (metadata, content);
     }
 
-    private static void DeleteCorrupt(string jsonPath)
+    private void DeleteCorrupt(string jsonPath)
     {
         try
         {
@@ -165,7 +168,11 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         }
         catch (Exception exception)
         {
-            Debug.WriteLine($"Corrupt {exception.Message}");
+            this._logger.CorruptFileDeletionFailed(
+                filename: jsonPath,
+                message: exception.Message,
+                exception: exception
+            );
         }
     }
 

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemPackageStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemPackageStorage.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -77,7 +76,11 @@ public sealed class FileSystemPackageStorage : IPackageStorage
                 }
                 catch (Exception exception)
                 {
-                    Debug.WriteLine($"Failed to delete temp file {tempPath}: {exception.Message}");
+                    this._logger.TempFileDeletionFailed(
+                        filename: tempPath,
+                        message: exception.Message,
+                        exception: exception
+                    );
                 }
             }
         }

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemPackageStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemPackageStorage.cs
@@ -36,6 +36,10 @@ public sealed class FileSystemPackageStorage : IPackageStorage
         {
             return null;
         }
+        catch (DirectoryNotFoundException)
+        {
+            return null;
+        }
         catch (Exception exception)
         {
             this._logger.FailedToReadFileFromCache(

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemPackageStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemPackageStorage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,12 +31,11 @@ public sealed class FileSystemPackageStorage : IPackageStorage
 
         try
         {
-            if (!File.Exists(packagePath))
-            {
-                return null;
-            }
-
             return await File.ReadAllBytesAsync(path: packagePath, cancellationToken: cancellationToken);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
         }
         catch (Exception exception)
         {
@@ -53,14 +53,33 @@ public sealed class FileSystemPackageStorage : IPackageStorage
     {
         (string packagePath, string dir) = this.BuildPackagePath(path: sourcePath);
 
+        string? tempPath = null;
+
         try
         {
             this.EnsureDirectoryExists(dir);
-            await File.WriteAllBytesAsync(path: packagePath, bytes: buffer, cancellationToken: cancellationToken);
+            tempPath = Path.Combine(dir, Path.GetRandomFileName());
+            await File.WriteAllBytesAsync(path: tempPath, bytes: buffer, cancellationToken: cancellationToken);
+            File.Move(sourceFileName: tempPath, destFileName: packagePath, overwrite: true);
+            tempPath = null;
         }
         catch (Exception exception)
         {
             this._logger.SaveFailed(filename: packagePath, message: exception.Message, exception: exception);
+        }
+        finally
+        {
+            if (tempPath is not null)
+            {
+                try
+                {
+                    File.Delete(tempPath);
+                }
+                catch (Exception exception)
+                {
+                    Debug.WriteLine($"Failed to delete temp file {tempPath}: {exception.Message}");
+                }
+            }
         }
     }
 

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/LoggingExtensions/FileSystemJsonStorageLoggerExtensions.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/LoggingExtensions/FileSystemJsonStorageLoggerExtensions.cs
@@ -20,4 +20,24 @@ internal static partial class FileSystemJsonStorageLoggerExtensions
         string message,
         Exception exception
     );
+
+    [LoggerMessage(LogLevel.Warning, EventId = 4, Message = "Failed to delete temp file {filename}: {message}")]
+    public static partial void TempFileDeletionFailed(
+        this ILogger<FileSystemJsonStorage> logger,
+        string filename,
+        string message,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        LogLevel.Warning,
+        EventId = 5,
+        Message = "Failed to delete corrupt cache file {filename}: {message}"
+    )]
+    public static partial void CorruptFileDeletionFailed(
+        this ILogger<FileSystemJsonStorage> logger,
+        string filename,
+        string message,
+        Exception exception
+    );
 }

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/LoggingExtensions/FileSystemPackageStorageLoggerExtensions.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/LoggingExtensions/FileSystemPackageStorageLoggerExtensions.cs
@@ -20,4 +20,12 @@ internal static partial class FileSystemPackageStorageLoggerExtensions
         string message,
         Exception exception
     );
+
+    [LoggerMessage(LogLevel.Warning, EventId = 4, Message = "Failed to delete temp file {filename}: {message}")]
+    public static partial void TempFileDeletionFailed(
+        this ILogger<FileSystemPackageStorage> logger,
+        string filename,
+        string message,
+        Exception exception
+    );
 }

--- a/src/Credfeto.Nuget.Proxy.Server/Credfeto.Nuget.Proxy.Server.csproj
+++ b/src/Credfeto.Nuget.Proxy.Server/Credfeto.Nuget.Proxy.Server.csproj
@@ -38,7 +38,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-nuget-porxy</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
-    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
     <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>


### PR DESCRIPTION
## Summary

- Replace direct `File.WriteAllBytesAsync`/`File.OpenWrite` writes with a write-to-temp-then-`File.Move` atomic rename pattern in both `FileSystemPackageStorage` and `FileSystemJsonStorage`
- Remove `File.Exists` guard before reads; catch `FileNotFoundException` explicitly instead to close the TOCTOU race
- Add tests for concurrent and interrupted write scenarios

## Additional changes

- `Credfeto.Nuget.Proxy.Server.csproj`: Set `SuppressTrimAnalysisWarnings` to `false` (pre-work buildcheck fix; build still passes)

## Test plan

- [ ] Existing 19 unit tests pass (verified locally)
- [ ] New concurrent-write tests for both `FileSystemPackageStorage` and `FileSystemJsonStorage` pass
- [ ] `dotnet buildcheck` passes cleanly

Closes #95