### PR TITLE
perf: Replace JSON+Base64Url cache format with binary format to eliminate per-request decompression overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Dependencies - Updated FunFair.Test.Source.Generator to 6.2.25.2243
 - Dependencies - Updated Microsoft.Extensions to 10.0.8
 - SDK - Updated DotNet SDK to 10.0.301
+- perf: Replace JSON+Base64Url cache format with binary format to eliminate per-request decompression overhead
 ### Removed
 - Serilog.Enrichers.Demystifier as Ben.Demystifier is incompatible with Native AOT (IL2104/IL3000/IL3002)
 ### Deployment Changes

--- a/src/Credfeto.Nuget.Proxy.Logic.Tests/Services/JsonDownloaderTests.cs
+++ b/src/Credfeto.Nuget.Proxy.Logic.Tests/Services/JsonDownloaderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -39,8 +39,7 @@ public sealed class JsonDownloaderTests : LoggingTestBase
     {
         CancellationToken cancellationToken = this.CancellationToken();
 
-        this._jsonStorage.LoadAsync(requestUri: Arg.Any<Uri>(), cancellationToken: Arg.Any<CancellationToken>())
-            .Returns(default((JsonMetadata metadata, string content)?));
+        MockJsonStorageLoadMetadata(storage: this._jsonStorage, result: null);
 
         using TestHttpMessageHandler handler = new(CreateJsonResponse(SAMPLE_JSON, etag: "\"etag1\""));
         using HttpClient client = new(handler);
@@ -61,8 +60,7 @@ public sealed class JsonDownloaderTests : LoggingTestBase
     {
         CancellationToken cancellationToken = this.CancellationToken();
 
-        this._jsonStorage.LoadAsync(requestUri: Arg.Any<Uri>(), cancellationToken: Arg.Any<CancellationToken>())
-            .Returns(default((JsonMetadata metadata, string content)?));
+        MockJsonStorageLoadMetadata(storage: this._jsonStorage, result: null);
 
         using TestHttpMessageHandler handler = new(CreateJsonResponse(SAMPLE_JSON, etag: "\"etag2\""));
         using HttpClient client = new(handler);
@@ -84,13 +82,14 @@ public sealed class JsonDownloaderTests : LoggingTestBase
     {
         CancellationToken cancellationToken = this.CancellationToken();
 
+        const string ETAG = "\"etag-cached\"";
         JsonMetadata cachedMetadata = new(
-            Etag: "\"etag-cached\"",
+            Etag: ETAG,
             ContentLength: SAMPLE_JSON.Length,
             ContentType: "application/json"
         );
-        this._jsonStorage.LoadAsync(requestUri: Arg.Any<Uri>(), cancellationToken: Arg.Any<CancellationToken>())
-            .Returns((cachedMetadata, SAMPLE_JSON));
+        MockJsonStorageLoadMetadata(storage: this._jsonStorage, result: cachedMetadata);
+        MockJsonStorageLoadResult(storage: this._jsonStorage, result: (cachedMetadata, SAMPLE_JSON));
 
         using TestHttpMessageHandler handler = new(new HttpResponseMessage(HttpStatusCode.NotModified));
         using HttpClient client = new(handler);
@@ -103,7 +102,7 @@ public sealed class JsonDownloaderTests : LoggingTestBase
         );
 
         Assert.Equal(expected: SAMPLE_JSON, actual: result.Json);
-        Assert.Equal(expected: "\"etag-cached\"", actual: result.ETag);
+        Assert.Equal(expected: ETAG, actual: result.ETag);
     }
 
     [Fact]
@@ -117,8 +116,8 @@ public sealed class JsonDownloaderTests : LoggingTestBase
             ContentLength: SAMPLE_JSON.Length,
             ContentType: "application/json"
         );
-        this._jsonStorage.LoadAsync(requestUri: Arg.Any<Uri>(), cancellationToken: Arg.Any<CancellationToken>())
-            .Returns((cachedMetadata, SAMPLE_JSON));
+        MockJsonStorageLoadMetadata(storage: this._jsonStorage, result: cachedMetadata);
+        MockJsonStorageLoadResult(storage: this._jsonStorage, result: (cachedMetadata, SAMPLE_JSON));
 
         using TestHttpMessageHandler handler = new(CreateJsonResponse(SAMPLE_JSON, etag: ETAG));
         using HttpClient client = new(handler);
@@ -139,8 +138,7 @@ public sealed class JsonDownloaderTests : LoggingTestBase
     {
         CancellationToken cancellationToken = this.CancellationToken();
 
-        this._jsonStorage.LoadAsync(requestUri: Arg.Any<Uri>(), cancellationToken: Arg.Any<CancellationToken>())
-            .Returns(default((JsonMetadata metadata, string content)?));
+        MockJsonStorageLoadMetadata(storage: this._jsonStorage, result: null);
 
         using TestHttpMessageHandler handler = new(CreateJsonResponse(SAMPLE_JSON, etag: null));
         using HttpClient client = new(handler);
@@ -161,8 +159,7 @@ public sealed class JsonDownloaderTests : LoggingTestBase
     {
         CancellationToken cancellationToken = this.CancellationToken();
 
-        this._jsonStorage.LoadAsync(requestUri: Arg.Any<Uri>(), cancellationToken: Arg.Any<CancellationToken>())
-            .Returns(default((JsonMetadata metadata, string content)?));
+        MockJsonStorageLoadMetadata(storage: this._jsonStorage, result: null);
 
         using TestHttpMessageHandler handler = new(new HttpResponseMessage(HttpStatusCode.NotFound));
         using HttpClient client = new(handler);
@@ -186,8 +183,8 @@ public sealed class JsonDownloaderTests : LoggingTestBase
             ContentLength: SAMPLE_JSON.Length,
             ContentType: "application/json"
         );
-        this._jsonStorage.LoadAsync(requestUri: Arg.Any<Uri>(), cancellationToken: Arg.Any<CancellationToken>())
-            .Returns((cachedMetadata, SAMPLE_JSON));
+        MockJsonStorageLoadMetadata(storage: this._jsonStorage, result: cachedMetadata);
+        MockJsonStorageLoadResult(storage: this._jsonStorage, result: null);
 
         const string NEW_JSON = """{"version":"3.0.1"}""";
         const string NEW_ETAG = "\"new-etag\"";
@@ -203,6 +200,18 @@ public sealed class JsonDownloaderTests : LoggingTestBase
 
         Assert.Equal(expected: NEW_JSON, actual: result.Json);
         Assert.Equal(expected: NEW_ETAG, actual: result.ETag);
+    }
+
+    private static void MockJsonStorageLoadMetadata(IJsonStorage storage, JsonMetadata? result)
+    {
+        storage
+            .LoadMetadataAsync(requestUri: Arg.Any<Uri>(), cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(result);
+    }
+
+    private static void MockJsonStorageLoadResult(IJsonStorage storage, (JsonMetadata metadata, string content)? result)
+    {
+        storage.LoadAsync(requestUri: Arg.Any<Uri>(), cancellationToken: Arg.Any<CancellationToken>()).Returns(result);
     }
 
     private IJsonDownloader CreateDownloader(HttpClient client)

--- a/src/Credfeto.Nuget.Proxy.Logic/Services/JsonDownloader.cs
+++ b/src/Credfeto.Nuget.Proxy.Logic/Services/JsonDownloader.cs
@@ -27,7 +27,12 @@ public sealed class JsonDownloader : IJsonDownloader
     private readonly IJsonStorage _jsonStorage;
     private readonly ILogger<JsonDownloader> _logger;
 
-    public JsonDownloader(IOptions<ProxyServerConfig> config, IHttpClientFactory httpClientFactory, IJsonStorage jsonStorage, ILogger<JsonDownloader> logger)
+    public JsonDownloader(
+        IOptions<ProxyServerConfig> config,
+        IHttpClientFactory httpClientFactory,
+        IJsonStorage jsonStorage,
+        ILogger<JsonDownloader> logger
+    )
     {
         this._config = config.Value;
         this._httpClientFactory = httpClientFactory;
@@ -35,61 +40,176 @@ public sealed class JsonDownloader : IJsonDownloader
         this._logger = logger;
     }
 
-    public async ValueTask<JsonResponse> ReadUpstreamAsync(Uri requestUri, ProductInfoHeaderValue? userAgent, CancellationToken cancellationToken)
+    public async ValueTask<JsonResponse> ReadUpstreamAsync(
+        Uri requestUri,
+        ProductInfoHeaderValue? userAgent,
+        CancellationToken cancellationToken
+    )
     {
         HttpClient client = this.GetClient(userAgent);
 
-        (JsonMetadata metadata, string content)? cached = await this._jsonStorage.LoadAsync(requestUri: requestUri, cancellationToken: cancellationToken);
+        JsonMetadata? cachedMetadata = await this._jsonStorage.LoadMetadataAsync(
+            requestUri: requestUri,
+            cancellationToken: cancellationToken
+        );
 
-        if (cached is not null && !string.IsNullOrWhiteSpace(cached.Value.metadata.Etag))
+        if (cachedMetadata.HasValue && !string.IsNullOrWhiteSpace(cachedMetadata.Value.Etag))
         {
-            this._logger.PreviouslyCached(upstream: requestUri, etag: cached.Value.metadata.Etag);
-            AddEtag(client: client, cached: cached.Value.metadata);
+            this._logger.PreviouslyCached(upstream: requestUri, etag: cachedMetadata.Value.Etag);
+            AddEtag(client: client, cached: cachedMetadata.Value);
         }
 
-        using (HttpResponseMessage result = await client.GetAsync(requestUri: requestUri, cancellationToken: cancellationToken))
-        {
-            if (cached is not null && result.StatusCode == HttpStatusCode.NotModified)
-            {
-                this._logger.ReturningCached(upstream: requestUri, metadata: cached.Value.metadata, httpStatus: result.StatusCode);
+        using HttpResponseMessage result = await client.GetAsync(
+            requestUri: requestUri,
+            cancellationToken: cancellationToken
+        );
 
-                // ! Should always have ETag at this point
-                return new JsonResponse(Json: cached.Value.content, ETag: cached.Value.metadata.Etag!);
-            }
-
-            if (!result.IsSuccessStatusCode)
-            {
-                return Failed(requestUri: requestUri, resultStatusCode: result.StatusCode);
-            }
-
-            string? eTag = ExtractHeaderValue(headers: result.Headers, name: "ETag");
-
-            if (cached is not null && !string.IsNullOrEmpty(cached.Value.metadata.Etag) && !string.IsNullOrWhiteSpace(eTag) && StringComparer.Ordinal.Equals(x: eTag, y: cached.Value.metadata.Etag))
-            {
-                this._logger.ReturningCached(upstream: requestUri, metadata: cached.Value.metadata, httpStatus: result.StatusCode);
-
-                return new JsonResponse(Json: cached.Value.content, ETag: cached.Value.metadata.Etag);
-            }
-
-            string json = await result.Content.ReadAsStringAsync(cancellationToken: cancellationToken);
-
-            JsonMetadata jsonMetadata = LoadMetadata(result: result, eTag: eTag, contentLength: json.Length);
-
-            this._logger.Metadata(upstream: requestUri, metadata: jsonMetadata, httpStatus: result.StatusCode);
-
-            await this.SaveToCacheAsync(requestUri: requestUri, jsonMetadata: jsonMetadata, json: json, cancellationToken: cancellationToken);
-
-            return new (Json: json, ETag:
-                        string.IsNullOrEmpty(jsonMetadata.Etag)
-                        ? HashJson(json)
-                        : jsonMetadata.Etag);
-        }
+        return await this.BuildResponseAsync(
+            requestUri: requestUri,
+            cachedMetadata: cachedMetadata,
+            result: result,
+            cancellationToken: cancellationToken
+        );
     }
 
-    private static  string HashJson(string json)
+    private async ValueTask<JsonResponse> BuildResponseAsync(
+        Uri requestUri,
+        JsonMetadata? cachedMetadata,
+        HttpResponseMessage result,
+        CancellationToken cancellationToken
+    )
     {
-        return Base64Url.EncodeToString(
-        SHA512.HashData(Encoding.UTF8.GetBytes(json)));
+        if (result.StatusCode == HttpStatusCode.NotModified)
+        {
+            JsonResponse? notModified = await this.TryBuildCachedResponseAsync(
+                requestUri: requestUri,
+                httpStatus: result.StatusCode,
+                cancellationToken: cancellationToken
+            );
+
+            if (notModified is not null)
+            {
+                return notModified.Value;
+            }
+        }
+
+        if (!result.IsSuccessStatusCode)
+        {
+            return Failed(requestUri: requestUri, resultStatusCode: result.StatusCode);
+        }
+
+        string? eTag = ExtractHeaderValue(headers: result.Headers, name: "ETag");
+
+        if (cachedMetadata.HasValue)
+        {
+            string? matchedETag = GetMatchedETag(cachedMetadata: cachedMetadata.Value, eTag: eTag);
+
+            if (matchedETag is not null)
+            {
+                JsonResponse? eTagMatch = await this.TryBuildCachedResponseOnETagMatchAsync(
+                    requestUri: requestUri,
+                    cachedMetadata: cachedMetadata.Value,
+                    cachedETag: matchedETag,
+                    httpStatus: result.StatusCode,
+                    cancellationToken: cancellationToken
+                );
+
+                if (eTagMatch is not null)
+                {
+                    return eTagMatch.Value;
+                }
+            }
+        }
+
+        return await this.DownloadAndCacheAsync(
+            requestUri: requestUri,
+            result: result,
+            eTag: eTag,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    private async ValueTask<JsonResponse?> TryBuildCachedResponseAsync(
+        Uri requestUri,
+        HttpStatusCode httpStatus,
+        CancellationToken cancellationToken
+    )
+    {
+        (JsonMetadata metadata, string content)? cached = await this._jsonStorage.LoadAsync(
+            requestUri: requestUri,
+            cancellationToken: cancellationToken
+        );
+
+        if (cached is null)
+        {
+            return null;
+        }
+
+        this._logger.ReturningCached(upstream: requestUri, metadata: cached.Value.metadata, httpStatus: httpStatus);
+
+        // ! Should always have ETag at this point
+        return new JsonResponse(Json: cached.Value.content, ETag: cached.Value.metadata.Etag!);
+    }
+
+    private async ValueTask<JsonResponse?> TryBuildCachedResponseOnETagMatchAsync(
+        Uri requestUri,
+        JsonMetadata cachedMetadata,
+        string cachedETag,
+        HttpStatusCode httpStatus,
+        CancellationToken cancellationToken
+    )
+    {
+        (JsonMetadata metadata, string content)? cached = await this._jsonStorage.LoadAsync(
+            requestUri: requestUri,
+            cancellationToken: cancellationToken
+        );
+
+        if (cached is null)
+        {
+            return null;
+        }
+
+        this._logger.ReturningCached(upstream: requestUri, metadata: cachedMetadata, httpStatus: httpStatus);
+
+        return new JsonResponse(Json: cached.Value.content, ETag: cachedETag);
+    }
+
+    private static string? GetMatchedETag(in JsonMetadata cachedMetadata, string? eTag)
+    {
+        if (string.IsNullOrEmpty(cachedMetadata.Etag) || string.IsNullOrWhiteSpace(eTag))
+        {
+            return null;
+        }
+
+        return StringComparer.Ordinal.Equals(x: eTag, y: cachedMetadata.Etag) ? cachedMetadata.Etag : null;
+    }
+
+    private async ValueTask<JsonResponse> DownloadAndCacheAsync(
+        Uri requestUri,
+        HttpResponseMessage result,
+        string? eTag,
+        CancellationToken cancellationToken
+    )
+    {
+        string json = await result.Content.ReadAsStringAsync(cancellationToken: cancellationToken);
+
+        JsonMetadata jsonMetadata = LoadMetadata(result: result, eTag: eTag, contentLength: json.Length);
+
+        this._logger.Metadata(upstream: requestUri, metadata: jsonMetadata, httpStatus: result.StatusCode);
+
+        await this.SaveToCacheAsync(
+            requestUri: requestUri,
+            jsonMetadata: jsonMetadata,
+            json: json,
+            cancellationToken: cancellationToken
+        );
+
+        return new(Json: json, ETag: string.IsNullOrEmpty(jsonMetadata.Etag) ? HashJson(json) : jsonMetadata.Etag);
+    }
+
+    private static string HashJson(string json)
+    {
+        return Base64Url.EncodeToString(SHA512.HashData(Encoding.UTF8.GetBytes(json)));
     }
 
     private static void AddEtag(HttpClient client, in JsonMetadata cached)
@@ -106,12 +226,15 @@ public sealed class JsonDownloader : IJsonDownloader
 
     private static string EnsureQuoted(string source)
     {
-        return source.StartsWith('"') && source.EndsWith('"')
-            ? source
-            : "\"" + source + "\"";
+        return source.StartsWith('"') && source.EndsWith('"') ? source : "\"" + source + "\"";
     }
 
-    private async ValueTask SaveToCacheAsync(Uri requestUri, JsonMetadata jsonMetadata, string json, CancellationToken cancellationToken)
+    private async ValueTask SaveToCacheAsync(
+        Uri requestUri,
+        JsonMetadata jsonMetadata,
+        string json,
+        CancellationToken cancellationToken
+    )
     {
         if (string.IsNullOrWhiteSpace(jsonMetadata.Etag) || string.IsNullOrWhiteSpace(jsonMetadata.ContentType))
         {
@@ -123,7 +246,12 @@ public sealed class JsonDownloader : IJsonDownloader
             return;
         }
 
-        await this._jsonStorage.SaveAsync(requestUri: requestUri, metadata: jsonMetadata, jsonContent: json, cancellationToken: cancellationToken);
+        await this._jsonStorage.SaveAsync(
+            requestUri: requestUri,
+            metadata: jsonMetadata,
+            jsonContent: json,
+            cancellationToken: cancellationToken
+        );
     }
 
     private static JsonMetadata LoadMetadata(HttpResponseMessage result, string? eTag, long contentLength)
@@ -136,14 +264,19 @@ public sealed class JsonDownloader : IJsonDownloader
     [DoesNotReturn]
     private static JsonResponse Failed(Uri requestUri, HttpStatusCode resultStatusCode)
     {
-        throw new HttpRequestException($"Failed to download {requestUri}: {resultStatusCode.GetName()}", inner: null, statusCode: resultStatusCode);
+        throw new HttpRequestException(
+            $"Failed to download {requestUri}: {resultStatusCode.GetName()}",
+            inner: null,
+            statusCode: resultStatusCode
+        );
     }
 
     private HttpClient GetClient(ProductInfoHeaderValue? userAgent)
     {
-        return this._httpClientFactory.CreateClient(HttpClientNames.Json)
-                   .WithBaseAddress(new(this._config.UpstreamUrls[0]))
-                   .WithUserAgent(userAgent);
+        return this
+            ._httpClientFactory.CreateClient(HttpClientNames.Json)
+            .WithBaseAddress(new(this._config.UpstreamUrls[0]))
+            .WithUserAgent(userAgent);
     }
 
     private static string? ExtractHeaderValue(HttpResponseHeaders headers, string name)

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemJsonStorageTests.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemJsonStorageTests.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Buffers.Text;
+using System.Buffers.Binary;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Credfeto.Nuget.Proxy.Models.Config;
@@ -51,6 +50,20 @@ public sealed class FileSystemJsonStorageTests : LoggingFolderCleanupTestBase
     }
 
     [Fact]
+    public async Task LoadMetadataAsync_WhenFileDoesNotExist_ReturnsNullAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+        Uri requestUri = new("https://api.nuget.org/v3/missing.json");
+
+        JsonMetadata? result = await this._jsonStorage.LoadMetadataAsync(
+            requestUri: requestUri,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.Null(result);
+    }
+
+    [Fact]
     public async Task SaveAndLoadRoundtripAsync()
     {
         CancellationToken cancellationToken = this.CancellationToken();
@@ -81,6 +94,37 @@ public sealed class FileSystemJsonStorageTests : LoggingFolderCleanupTestBase
     }
 
     [Fact]
+    public async Task SaveAndLoadMetadataRoundtripAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+        Uri requestUri = new("https://api.nuget.org/v3/meta-roundtrip.json");
+
+        const string JSON_CONTENT = """{"version":"3.0.0"}""";
+        JsonMetadata metadata = new(
+            Etag: "\"meta-etag\"",
+            ContentLength: JSON_CONTENT.Length,
+            ContentType: "application/json"
+        );
+
+        await this._jsonStorage.SaveAsync(
+            requestUri: requestUri,
+            metadata: metadata,
+            jsonContent: JSON_CONTENT,
+            cancellationToken: cancellationToken
+        );
+
+        JsonMetadata? result = await this._jsonStorage.LoadMetadataAsync(
+            requestUri: requestUri,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: "\"meta-etag\"", actual: result.Value.Etag);
+        Assert.Equal(expected: JSON_CONTENT.Length, actual: result.Value.ContentLength);
+        Assert.Equal(expected: "application/json", actual: result.Value.ContentType);
+    }
+
+    [Fact]
     public async Task LoadAsync_WhenFileIsCorrupt_ReturnsNullAsync()
     {
         CancellationToken cancellationToken = this.CancellationToken();
@@ -92,7 +136,55 @@ public sealed class FileSystemJsonStorageTests : LoggingFolderCleanupTestBase
 
         await File.WriteAllTextAsync(
             path: filePath,
-            contents: "this is not valid json",
+            contents: "this is not valid binary format",
+            cancellationToken: cancellationToken
+        );
+
+        (JsonMetadata metadata, string content)? result = await this._jsonStorage.LoadAsync(
+            requestUri: requestUri,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task LoadMetadataAsync_WhenFileIsCorrupt_ReturnsNullAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+        Uri requestUri = new("https://api.nuget.org/v3/corrupted-meta.json");
+
+        string dir = Path.Combine(path1: this.TempFolder, path2: "api.nuget.org/v3");
+        Directory.CreateDirectory(dir);
+        string filePath = Path.Combine(path1: dir, path2: "corrupted-meta.json");
+
+        await File.WriteAllTextAsync(
+            path: filePath,
+            contents: "this is not valid binary format",
+            cancellationToken: cancellationToken
+        );
+
+        JsonMetadata? result = await this._jsonStorage.LoadMetadataAsync(
+            requestUri: requestUri,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenFileHasOldJsonFormat_ReturnsNullAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+        Uri requestUri = new("https://api.nuget.org/v3/oldfmt.json");
+
+        string dir = Path.Combine(path1: this.TempFolder, path2: "api.nuget.org/v3");
+        Directory.CreateDirectory(dir);
+        string filePath = Path.Combine(path1: dir, path2: "oldfmt.json");
+
+        await File.WriteAllTextAsync(
+            path: filePath,
+            contents: """{"etag":"\"e\"","size":3,"contentType":"application/json","content":"abc"}""",
             cancellationToken: cancellationToken
         );
 
@@ -114,12 +206,14 @@ public sealed class FileSystemJsonStorageTests : LoggingFolderCleanupTestBase
         Directory.CreateDirectory(dir);
         string filePath = Path.Combine(path1: dir, path2: "whitespace.json");
 
-        string compressedWhitespace = await CompressToBase64UrlAsync("   ", cancellationToken);
-
-        string jsonItem =
-            $$$"""{"etag":"etag","size":3,"contentType":"application/json","content":"{{{compressedWhitespace}}}"}""";
-
-        await File.WriteAllTextAsync(path: filePath, contents: jsonItem, cancellationToken: cancellationToken);
+        await WriteBinaryFormatFileAsync(
+            filePath: filePath,
+            etag: "etag",
+            size: 3,
+            contentType: "application/json",
+            content: "   ",
+            cancellationToken: cancellationToken
+        );
 
         (JsonMetadata metadata, string content)? result = await this._jsonStorage.LoadAsync(
             requestUri: requestUri,
@@ -156,26 +250,6 @@ public sealed class FileSystemJsonStorageTests : LoggingFolderCleanupTestBase
     }
 
     [Fact]
-    public async Task LoadAsync_WhenDeserializedItemIsNull_ReturnsNullAsync()
-    {
-        CancellationToken cancellationToken = this.CancellationToken();
-        Uri requestUri = new("https://api.nuget.org/v3/nullitem.json");
-
-        string dir = Path.Combine(path1: this.TempFolder, path2: "api.nuget.org/v3");
-        Directory.CreateDirectory(dir);
-        string filePath = Path.Combine(path1: dir, path2: "nullitem.json");
-
-        await File.WriteAllTextAsync(path: filePath, contents: "null", cancellationToken: cancellationToken);
-
-        (JsonMetadata metadata, string content)? result = await this._jsonStorage.LoadAsync(
-            requestUri: requestUri,
-            cancellationToken: cancellationToken
-        );
-
-        Assert.Null(result);
-    }
-
-    [Fact]
     public async Task LoadAsync_WhenFileIsUnreadable_ReturnsNullAsync()
     {
         if (!OperatingSystem.IsLinux())
@@ -209,6 +283,39 @@ public sealed class FileSystemJsonStorageTests : LoggingFolderCleanupTestBase
     }
 
     [Fact]
+    public async Task LoadMetadataAsync_WhenFileIsUnreadable_ReturnsNullAsync()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        CancellationToken cancellationToken = this.CancellationToken();
+        Uri requestUri = new("https://api.nuget.org/v3/unreadable-meta.json");
+
+        string dir = Path.Combine(path1: this.TempFolder, path2: "api.nuget.org/v3");
+        Directory.CreateDirectory(dir);
+        string filePath = Path.Combine(path1: dir, path2: "unreadable-meta.json");
+
+        await File.WriteAllTextAsync(path: filePath, contents: "content", cancellationToken: cancellationToken);
+        File.SetUnixFileMode(path: filePath, mode: UnixFileMode.None);
+
+        try
+        {
+            JsonMetadata? result = await this._jsonStorage.LoadMetadataAsync(
+                requestUri: requestUri,
+                cancellationToken: cancellationToken
+            );
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            File.SetUnixFileMode(path: filePath, mode: UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+    }
+
+    [Fact]
     public async Task LoadAsync_WhenCorruptFileCannotBeDeleted_ReturnsNullAsync()
     {
         if (!OperatingSystem.IsLinux())
@@ -223,7 +330,11 @@ public sealed class FileSystemJsonStorageTests : LoggingFolderCleanupTestBase
         Directory.CreateDirectory(dir);
         string filePath = Path.Combine(path1: dir, path2: "nodelete.json");
 
-        await File.WriteAllTextAsync(path: filePath, contents: "not valid json", cancellationToken: cancellationToken);
+        await File.WriteAllTextAsync(
+            path: filePath,
+            contents: "not valid binary format",
+            cancellationToken: cancellationToken
+        );
         File.SetUnixFileMode(path: dir, mode: UnixFileMode.UserRead | UnixFileMode.UserExecute);
 
         try
@@ -397,21 +508,33 @@ public sealed class FileSystemJsonStorageTests : LoggingFolderCleanupTestBase
         Assert.Equal(expected: ORIGINAL_CONTENT, actual: result.Value.content);
     }
 
-    private static async ValueTask<string> CompressToBase64UrlAsync(string source, CancellationToken cancellationToken)
+    private static async ValueTask WriteBinaryFormatFileAsync(
+        string filePath,
+        string etag,
+        long size,
+        string contentType,
+        string content,
+        CancellationToken cancellationToken
+    )
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(source);
+        byte[] magic = [(byte)'N', (byte)'G', (byte)'J', (byte)'B'];
+        const byte version = 1;
 
-        await using MemoryStream output = new();
+        string metaJson = $$$"""{"etag":"{{{etag}}}","size":{{{size}}},"contentType":"{{{contentType}}}"}""";
+        byte[] metaBytes = Encoding.UTF8.GetBytes(metaJson);
 
-        await using (MemoryStream input = new(buffer: bytes, writable: false))
-        {
-            await using BrotliStream stream = new(stream: output, compressionLevel: CompressionLevel.SmallestSize);
+        await using FileStream stream = File.Create(filePath);
+        await stream.WriteAsync(buffer: magic, cancellationToken: cancellationToken);
+        stream.WriteByte(version);
 
-            await input.CopyToAsync(destination: stream, cancellationToken: cancellationToken);
-        }
+        byte[] lengthBuffer = new byte[4];
+        BinaryPrimitives.WriteUInt32LittleEndian(destination: lengthBuffer, value: (uint)metaBytes.Length);
+        await stream.WriteAsync(buffer: lengthBuffer, cancellationToken: cancellationToken);
 
-        await output.FlushAsync(cancellationToken);
+        await stream.WriteAsync(buffer: metaBytes, cancellationToken: cancellationToken);
 
-        return Base64Url.EncodeToString(output.ToArray());
+        await using BrotliStream brotli = new(stream: stream, compressionLevel: CompressionLevel.Optimal);
+        await using StreamWriter writer = new(stream: brotli, encoding: Encoding.UTF8, leaveOpen: true);
+        await writer.WriteAsync(content.AsMemory(), cancellationToken);
     }
 }

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Buffers.Text;
+using System.Buffers.Binary;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
@@ -19,6 +19,10 @@ namespace Credfeto.Nuget.Proxy.Package.Storage.FileSystem;
 
 public sealed class FileSystemJsonStorage : IJsonStorage
 {
+    private static readonly byte[] Magic = [(byte)'N', (byte)'G', (byte)'J', (byte)'B'];
+    private const byte FormatVersion = 1;
+    private const int HeaderSize = 4 + 1 + 4;
+
     private readonly string _basePath;
     private readonly ILogger<FileSystemJsonStorage> _logger;
 
@@ -46,25 +50,25 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         {
             this.EnsureDirectoryExists(dir);
 
-            string compressed = await CompressAsync(source: jsonContent, cancellationToken: cancellationToken);
-
-            JsonItem item = new(
-                metadata.Etag ?? "",
-                size: jsonContent.Length,
-                metadata.ContentType ?? "",
-                content: compressed
+            byte[] metaBytes = SerializeMetadata(
+                new(
+                    etag: metadata.Etag ?? string.Empty,
+                    size: metadata.ContentLength,
+                    contentType: metadata.ContentType ?? string.Empty
+                )
             );
 
             tempPath = Path.Combine(dir, Path.GetRandomFileName());
 
             await using (Stream stream = File.Create(tempPath))
             {
-                await JsonSerializer.SerializeAsync(
-                    utf8Json: stream,
-                    value: item,
-                    jsonTypeInfo: FileSystemJsonContext.Default.JsonItem,
-                    cancellationToken: cancellationToken
-                );
+                WriteHeader(stream: stream, metaBytes: metaBytes);
+
+                await stream.WriteAsync(buffer: metaBytes, cancellationToken: cancellationToken);
+
+                await using BrotliStream brotli = new(stream: stream, compressionLevel: CompressionLevel.Optimal);
+                await using StreamWriter writer = new(stream: brotli, encoding: Encoding.UTF8, leaveOpen: true);
+                await writer.WriteAsync(jsonContent.AsMemory(), cancellationToken);
             }
 
             File.Move(sourceFileName: tempPath, destFileName: jsonPath, overwrite: true);
@@ -94,16 +98,41 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         }
     }
 
-    public async ValueTask<(JsonMetadata metadata, string content)?> LoadAsync(
+    public ValueTask<JsonMetadata?> LoadMetadataAsync(Uri requestUri, CancellationToken cancellationToken)
+    {
+        (string jsonPath, _) = this.BuildJsonPath(sourceHost: requestUri.Host, path: requestUri.AbsolutePath);
+
+        return this.ReadFromCacheAsync(
+            jsonPath: jsonPath,
+            readAsync: ReadMetadataFromFileAsync,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public ValueTask<(JsonMetadata metadata, string content)?> LoadAsync(
         Uri requestUri,
         CancellationToken cancellationToken
     )
     {
         (string jsonPath, _) = this.BuildJsonPath(sourceHost: requestUri.Host, path: requestUri.AbsolutePath);
 
+        return this.ReadFromCacheAsync(
+            jsonPath: jsonPath,
+            readAsync: ReadFromFileAsync,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    private async ValueTask<T?> ReadFromCacheAsync<T>(
+        string jsonPath,
+        Func<string, CancellationToken, ValueTask<T?>> readAsync,
+        CancellationToken cancellationToken
+    )
+        where T : struct
+    {
         try
         {
-            return await ReadFromFileAsync(jsonPath: jsonPath, cancellationToken: cancellationToken);
+            return await readAsync(jsonPath, cancellationToken);
         }
         catch (FileNotFoundException)
         {
@@ -136,6 +165,23 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         }
     }
 
+    private static async ValueTask<JsonMetadata?> ReadMetadataFromFileAsync(
+        string jsonPath,
+        CancellationToken cancellationToken
+    )
+    {
+        await using Stream stream = File.OpenRead(path: jsonPath);
+
+        JsonItem? item = await ReadHeaderAndMetadataAsync(stream: stream, cancellationToken: cancellationToken);
+
+        if (item is null)
+        {
+            return null;
+        }
+
+        return new JsonMetadata(Etag: item.Etag, ContentLength: item.Size, ContentType: item.ContentType);
+    }
+
     private static async ValueTask<(JsonMetadata metadata, string content)?> ReadFromFileAsync(
         string jsonPath,
         CancellationToken cancellationToken
@@ -143,21 +189,108 @@ public sealed class FileSystemJsonStorage : IJsonStorage
     {
         await using Stream stream = File.OpenRead(path: jsonPath);
 
-        JsonItem? item = await JsonSerializer.DeserializeAsync(
-            utf8Json: stream,
-            jsonTypeInfo: FileSystemJsonContext.Default.JsonItem,
-            cancellationToken: cancellationToken
-        );
+        JsonItem? item = await ReadHeaderAndMetadataAsync(stream: stream, cancellationToken: cancellationToken);
 
         if (item is null)
         {
             return null;
         }
 
-        JsonMetadata metadata = new(Etag: item.Etag, ContentLength: item.Size, ContentType: item.ContentType);
-        string content = await DecompressAsync(source: item.Content, cancellationToken: cancellationToken);
+        string content = await DecompressBodyAsync(stream: stream, cancellationToken: cancellationToken);
 
-        return string.IsNullOrWhiteSpace(content) ? null : (metadata, content);
+        return string.IsNullOrWhiteSpace(content)
+            ? null
+            : (new JsonMetadata(Etag: item.Etag, ContentLength: item.Size, ContentType: item.ContentType), content);
+    }
+
+    private static async ValueTask<JsonItem?> ReadHeaderAndMetadataAsync(
+        Stream stream,
+        CancellationToken cancellationToken
+    )
+    {
+        byte[] header = new byte[HeaderSize];
+
+        if (!await ReadExactAsync(stream: stream, buffer: header, cancellationToken: cancellationToken))
+        {
+            return null;
+        }
+
+        if (!IsMagicValid(header))
+        {
+            return null;
+        }
+
+        if (header[4] != FormatVersion)
+        {
+            return null;
+        }
+
+        uint metaLength = BinaryPrimitives.ReadUInt32LittleEndian(header.AsSpan(5));
+
+        if (metaLength > 1024 * 1024)
+        {
+            return null;
+        }
+
+        byte[] metaBytes = new byte[metaLength];
+
+        if (!await ReadExactAsync(stream: stream, buffer: metaBytes, cancellationToken: cancellationToken))
+        {
+            return null;
+        }
+
+        return JsonSerializer.Deserialize(utf8Json: metaBytes, jsonTypeInfo: FileSystemJsonContext.Default.JsonItem);
+    }
+
+    private static bool IsMagicValid(byte[] header)
+    {
+        return header[0] == Magic[0] && header[1] == Magic[1] && header[2] == Magic[2] && header[3] == Magic[3];
+    }
+
+    private static async ValueTask<bool> ReadExactAsync(
+        Stream stream,
+        byte[] buffer,
+        CancellationToken cancellationToken
+    )
+    {
+        int totalRead = 0;
+
+        while (totalRead < buffer.Length)
+        {
+            int read = await stream.ReadAsync(buffer: buffer.AsMemory(totalRead), cancellationToken: cancellationToken);
+
+            if (read == 0)
+            {
+                return false;
+            }
+
+            totalRead += read;
+        }
+
+        return true;
+    }
+
+    private static async ValueTask<string> DecompressBodyAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        await using BrotliStream brotli = new(stream: stream, mode: CompressionMode.Decompress, leaveOpen: true);
+        using StreamReader reader = new(stream: brotli, encoding: Encoding.UTF8, leaveOpen: true);
+
+        return await reader.ReadToEndAsync(cancellationToken);
+    }
+
+    private static byte[] SerializeMetadata(JsonItem item)
+    {
+        return JsonSerializer.SerializeToUtf8Bytes(value: item, jsonTypeInfo: FileSystemJsonContext.Default.JsonItem);
+    }
+
+    private static void WriteHeader(Stream stream, byte[] metaBytes)
+    {
+        stream.Write(buffer: Magic);
+        stream.WriteByte(FormatVersion);
+
+        Span<byte> lengthBuffer = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32LittleEndian(destination: lengthBuffer, value: (uint)metaBytes.Length);
+        stream.Write(buffer: lengthBuffer);
     }
 
     private void DeleteCorrupt(string jsonPath)
@@ -198,45 +331,6 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         catch (Exception exception)
         {
             this._logger.SaveFailed(filename: folder, message: exception.Message, exception: exception);
-        }
-    }
-
-    private static async ValueTask<string> CompressAsync(string source, CancellationToken cancellationToken)
-    {
-        byte[] bytes = Encoding.UTF8.GetBytes(source);
-
-        await using (MemoryStream output = new())
-        {
-            await using (MemoryStream input = new(buffer: bytes, writable: false))
-            {
-                await using (BrotliStream stream = new(stream: output, compressionLevel: CompressionLevel.SmallestSize))
-                {
-                    await input.CopyToAsync(destination: stream, cancellationToken: cancellationToken);
-                }
-            }
-
-            await output.FlushAsync(cancellationToken);
-
-            return Base64Url.EncodeToString(output.ToArray());
-        }
-    }
-
-    private static async ValueTask<string> DecompressAsync(string source, CancellationToken cancellationToken)
-    {
-        byte[] bytes = Base64Url.DecodeFromChars(source);
-
-        await using (MemoryStream output = new())
-        {
-            await using (MemoryStream input = new(buffer: bytes, writable: true))
-            {
-                await using (BrotliStream stream = new(stream: input, mode: CompressionMode.Decompress))
-                {
-                    await stream.CopyToAsync(destination: output, cancellationToken: cancellationToken);
-                }
-
-                await output.FlushAsync(cancellationToken);
-                return Encoding.UTF8.GetString(output.ToArray());
-            }
         }
     }
 }

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.Interfaces/IJsonStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.Interfaces/IJsonStorage.cs
@@ -7,6 +7,8 @@ namespace Credfeto.Nuget.Proxy.Package.Storage.Interfaces;
 
 public interface IJsonStorage
 {
+    ValueTask<JsonMetadata?> LoadMetadataAsync(Uri requestUri, CancellationToken cancellationToken);
+
     ValueTask<(JsonMetadata metadata, string content)?> LoadAsync(Uri requestUri, CancellationToken cancellationToken);
 
     ValueTask SaveAsync(Uri requestUri, JsonMetadata metadata, string jsonContent, CancellationToken cancellationToken);

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.Interfaces/Models/JsonItem.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.Interfaces/Models/JsonItem.cs
@@ -3,16 +3,15 @@ using System.Text.Json.Serialization;
 
 namespace Credfeto.Nuget.Proxy.Package.Storage.Interfaces.Models;
 
-[DebuggerDisplay("Etag: {Etag} Size: {Size}  Content: {Content}")]
+[DebuggerDisplay("Etag: {Etag} Size: {Size} ContentType: {ContentType}")]
 public sealed class JsonItem
 {
     [JsonConstructor]
-    public JsonItem(string etag, long size, string contentType, string content)
+    public JsonItem(string etag, long size, string contentType)
     {
         this.Etag = etag;
         this.Size = size;
         this.ContentType = contentType;
-        this.Content = content;
     }
 
     public string Etag { get; }
@@ -20,6 +19,4 @@ public sealed class JsonItem
     public long Size { get; }
 
     public string ContentType { get; }
-
-    public string Content { get; }
 }


### PR DESCRIPTION
## Summary

- Replace the JSON+Base64Url cache file format with a binary format: 4-byte magic (`NGJB`), 1-byte version, 4-byte LE uint32 metadata length, compact metadata JSON, then raw Brotli bytes — written atomically via temp+`File.Move`
- Add `LoadMetadataAsync` to `IJsonStorage` so `JsonDownloader` can fetch only the ETag without triggering full decompression on every request
- Change compression from `CompressionLevel.SmallestSize` to `CompressionLevel.Optimal` and stream Brotli output directly to the temp `FileStream`, eliminating intermediate `MemoryStream`+`ToArray()`+Base64 allocations
- Add benchmark project and unit tests for the new format

## Test plan

- [ ] Round-trip save+load (metadata and content)
- [ ] Metadata-only load returns correct ETag without decompressing the Brotli body
- [ ] Corrupt/truncated file → null (cache miss)
- [ ] Old JSON+Base64 format file → null (cache miss, treated as stale)
- [ ] Concurrent atomic-write behaviour (temp+`File.Move`) still holds
- [ ] `JsonDownloader` calls `LoadMetadataAsync` on every request; full `LoadAsync` only on 304/ETag-match branches
- [ ] Benchmarks with `AssertAllocationsAtMost` thresholds for compress+save and load+decompress

Closes #102