### PR TITLE
perf: Return 304 Not Modified from JsonMiddleware when If-None-Match matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Enable trimmed publish for the service
 - Tests to achieve 100% line coverage across all testable projects
 - Enable Native AOT compilation for published service
-- Placeholder: Return 304 Not Modified from JsonMiddleware when If-None-Match matches the response ETag (#101)
+- Return 304 Not Modified from JsonMiddleware when the client's If-None-Match header matches the response ETag, avoiding a full re-transformed body on repeat metadata requests (#101)
 ### Fixed
 - Use EphemeralKeySet when loading HTTPS certificate to fix Docker container startup failure
 - Re-enabled Native AOT compilation and trimming by adding SuppressTrimAnalysisWarnings to suppress third-party IL2104 warnings blocking dotnet publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Enable trimmed publish for the service
 - Tests to achieve 100% line coverage across all testable projects
 - Enable Native AOT compilation for published service
+- Placeholder: Return 304 Not Modified from JsonMiddleware when If-None-Match matches the response ETag (#101)
 ### Fixed
 - Use EphemeralKeySet when loading HTTPS certificate to fix Docker container startup failure
 - Re-enabled Native AOT compilation and trimming by adding SuppressTrimAnalysisWarnings to suppress third-party IL2104 warnings blocking dotnet publish

--- a/src/Credfeto.Nuget.Proxy.Middleware.Tests/JsonMiddlewareTests.cs
+++ b/src/Credfeto.Nuget.Proxy.Middleware.Tests/JsonMiddlewareTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
@@ -337,6 +337,186 @@ public sealed class JsonMiddlewareTests : LoggingTestBase
         );
 
         Assert.Equal(expected: HttpStatusCode.OK, actual: response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_Returns304_WhenIfNoneMatchMatchesETagAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        const string JSON = """{"version":"3.0.0"}""";
+        const string ETAG = "\"abc123\"";
+        IJsonTransformer transformer = Substitute.For<IJsonTransformer>();
+        transformer.IsNuget.Returns(false);
+        transformer
+            .GetFromUpstreamAsync(
+                path: Arg.Any<string>(),
+                userAgent: Arg.Any<System.Net.Http.Headers.ProductInfoHeaderValue?>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(new JsonResult(Json: JSON, CacheMaxAgeSeconds: 60, ETag: ETAG));
+
+        using IHost host = BuildHost(transformer);
+        await host.StartAsync(cancellationToken);
+
+        using HttpClient client = host.GetTestClient();
+        using HttpRequestMessage request = new(
+            method: HttpMethod.Get,
+            requestUri: new Uri(uriString: "/v3/index.json", UriKind.Relative)
+        );
+        request.Headers.TryAddWithoutValidation(name: "If-None-Match", value: ETAG);
+        using HttpResponseMessage response = await client.SendAsync(
+            request: request,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.Equal(expected: HttpStatusCode.NotModified, actual: response.StatusCode);
+        string body = await response.Content.ReadAsStringAsync(cancellationToken);
+        Assert.Empty(body);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_Returns304_WhenIfNoneMatchWeakMatchesStrongETagAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        const string JSON = """{"version":"3.0.0"}""";
+        const string ETAG = "\"abc123\"";
+        IJsonTransformer transformer = Substitute.For<IJsonTransformer>();
+        transformer.IsNuget.Returns(false);
+        transformer
+            .GetFromUpstreamAsync(
+                path: Arg.Any<string>(),
+                userAgent: Arg.Any<System.Net.Http.Headers.ProductInfoHeaderValue?>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(new JsonResult(Json: JSON, CacheMaxAgeSeconds: 60, ETag: ETAG));
+
+        using IHost host = BuildHost(transformer);
+        await host.StartAsync(cancellationToken);
+
+        using HttpClient client = host.GetTestClient();
+        using HttpRequestMessage request = new(
+            method: HttpMethod.Get,
+            requestUri: new Uri(uriString: "/v3/index.json", UriKind.Relative)
+        );
+        request.Headers.TryAddWithoutValidation(name: "If-None-Match", value: "W/" + ETAG);
+        using HttpResponseMessage response = await client.SendAsync(
+            request: request,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.Equal(expected: HttpStatusCode.NotModified, actual: response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_Returns304_WhenIfNoneMatchIsWildcardAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        const string JSON = """{"version":"3.0.0"}""";
+        const string ETAG = "\"abc123\"";
+        IJsonTransformer transformer = Substitute.For<IJsonTransformer>();
+        transformer.IsNuget.Returns(false);
+        transformer
+            .GetFromUpstreamAsync(
+                path: Arg.Any<string>(),
+                userAgent: Arg.Any<System.Net.Http.Headers.ProductInfoHeaderValue?>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(new JsonResult(Json: JSON, CacheMaxAgeSeconds: 60, ETag: ETAG));
+
+        using IHost host = BuildHost(transformer);
+        await host.StartAsync(cancellationToken);
+
+        using HttpClient client = host.GetTestClient();
+        using HttpRequestMessage request = new(
+            method: HttpMethod.Get,
+            requestUri: new Uri(uriString: "/v3/index.json", UriKind.Relative)
+        );
+        request.Headers.TryAddWithoutValidation(name: "If-None-Match", value: "*");
+        using HttpResponseMessage response = await client.SendAsync(
+            request: request,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.Equal(expected: HttpStatusCode.NotModified, actual: response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_Returns200_WhenIfNoneMatchDoesNotMatchAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        const string JSON = """{"version":"3.0.0"}""";
+        const string ETAG = "\"abc123\"";
+        IJsonTransformer transformer = Substitute.For<IJsonTransformer>();
+        transformer.IsNuget.Returns(false);
+        transformer
+            .GetFromUpstreamAsync(
+                path: Arg.Any<string>(),
+                userAgent: Arg.Any<System.Net.Http.Headers.ProductInfoHeaderValue?>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(new JsonResult(Json: JSON, CacheMaxAgeSeconds: 60, ETag: ETAG));
+
+        using IHost host = BuildHost(transformer);
+        await host.StartAsync(cancellationToken);
+
+        using HttpClient client = host.GetTestClient();
+        using HttpRequestMessage request = new(
+            method: HttpMethod.Get,
+            requestUri: new Uri(uriString: "/v3/index.json", UriKind.Relative)
+        );
+        request.Headers.TryAddWithoutValidation(name: "If-None-Match", value: "\"different\"");
+        using HttpResponseMessage response = await client.SendAsync(
+            request: request,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.Equal(expected: HttpStatusCode.OK, actual: response.StatusCode);
+        string body = await response.Content.ReadAsStringAsync(cancellationToken);
+        Assert.Equal(expected: JSON, actual: body);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_Returns304_WithETagAndCacheControlHeadersAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        const string JSON = """{"version":"3.0.0"}""";
+        const string ETAG = "\"abc123\"";
+        IJsonTransformer transformer = Substitute.For<IJsonTransformer>();
+        transformer.IsNuget.Returns(false);
+        transformer
+            .GetFromUpstreamAsync(
+                path: Arg.Any<string>(),
+                userAgent: Arg.Any<System.Net.Http.Headers.ProductInfoHeaderValue?>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(new JsonResult(Json: JSON, CacheMaxAgeSeconds: 60, ETag: ETAG));
+
+        using IHost host = BuildHost(transformer);
+        await host.StartAsync(cancellationToken);
+
+        using HttpClient client = host.GetTestClient();
+        using HttpRequestMessage request = new(
+            method: HttpMethod.Get,
+            requestUri: new Uri(uriString: "/v3/index.json", UriKind.Relative)
+        );
+        request.Headers.TryAddWithoutValidation(name: "If-None-Match", value: ETAG);
+        using HttpResponseMessage response = await client.SendAsync(
+            request: request,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.Equal(expected: HttpStatusCode.NotModified, actual: response.StatusCode);
+        Assert.True(response.Headers.Contains("ETag"), userMessage: "ETag header should be present");
+        Assert.True(response.Headers.CacheControl?.Public, userMessage: "Cache-Control should be public");
+        Assert.True(
+            response.Headers.CacheControl?.MustRevalidate,
+            userMessage: "Cache-Control should require revalidation"
+        );
     }
 
     [Fact]

--- a/src/Credfeto.Nuget.Proxy.Middleware/JsonMiddleware.cs
+++ b/src/Credfeto.Nuget.Proxy.Middleware/JsonMiddleware.cs
@@ -19,19 +19,23 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Polly.Bulkhead;
 using Polly.Timeout;
+using EntityTagHeaderValue = Microsoft.Net.Http.Headers.EntityTagHeaderValue;
 
 namespace Credfeto.Nuget.Proxy.Middleware;
 
 public sealed class JsonMiddleware : IMiddleware
 {
-    private static readonly IReadOnlyList<string> WhiteListedPaths = [
-        "/autocomplete/query",
-        "/search/query"];
+    private static readonly IReadOnlyList<string> WhiteListedPaths = ["/autocomplete/query", "/search/query"];
     private readonly ICurrentTimeSource _currentTimeSource;
     private readonly ILogger<JsonMiddleware> _logger;
     private readonly IJsonTransformer _jsonTransformer;
 
-    public JsonMiddleware(IOptions<ProxyServerConfig> config, IEnumerable<IJsonTransformer> jsonTransformer, ICurrentTimeSource currentTimeSource, ILogger<JsonMiddleware> logger)
+    public JsonMiddleware(
+        IOptions<ProxyServerConfig> config,
+        IEnumerable<IJsonTransformer> jsonTransformer,
+        ICurrentTimeSource currentTimeSource,
+        ILogger<JsonMiddleware> logger
+    )
     {
         this._jsonTransformer = jsonTransformer.First(t => t.IsNuget == config.Value.IsNugetPublicServer);
         this._currentTimeSource = currentTimeSource;
@@ -53,20 +57,13 @@ public sealed class JsonMiddleware : IMiddleware
 
         try
         {
-            JsonResult? result = await this._jsonTransformer.GetFromUpstreamAsync(path: path, userAgent: userAgent, cancellationToken: cancellationToken);
-
-            if (result is null)
-            {
-                this._logger.NoUpstreamJson(path);
-                await next(context);
-
-                return;
-            }
-
-            this._logger.FoundUpstreamJson(path: path, cacheSeconds: result.Value.CacheMaxAgeSeconds);
-            int ageSeconds = result.Value.CacheMaxAgeSeconds;
-            string json = result.Value.Json;
-            await this.SuccessAsync(context: context, json: json, ageSeconds: ageSeconds, eTag: result.Value.ETag, cancellationToken: cancellationToken);
+            await this.ServeUpstreamAsync(
+                context: context,
+                next: next,
+                path: path,
+                userAgent: userAgent,
+                cancellationToken: cancellationToken
+            );
         }
         catch (HttpRequestException exception)
         {
@@ -79,7 +76,12 @@ public sealed class JsonMiddleware : IMiddleware
             }
             else
             {
-                this._logger.HttpError(path: path, statusCode: errorCode, message: exception.Message, exception: exception);
+                this._logger.HttpError(
+                    path: path,
+                    statusCode: errorCode,
+                    message: exception.Message,
+                    exception: exception
+                );
 
                 Failed(context: context, result: errorCode);
             }
@@ -101,9 +103,45 @@ public sealed class JsonMiddleware : IMiddleware
         }
     }
 
+    private async Task ServeUpstreamAsync(
+        HttpContext context,
+        RequestDelegate next,
+        string path,
+        ProductInfoHeaderValue? userAgent,
+        CancellationToken cancellationToken
+    )
+    {
+        JsonResult? result = await this._jsonTransformer.GetFromUpstreamAsync(
+            path: path,
+            userAgent: userAgent,
+            cancellationToken: cancellationToken
+        );
+
+        if (result is null)
+        {
+            this._logger.NoUpstreamJson(path);
+            await next(context);
+
+            return;
+        }
+
+        this._logger.FoundUpstreamJson(path: path, cacheSeconds: result.Value.CacheMaxAgeSeconds);
+        await this.SuccessAsync(
+            context: context,
+            json: result.Value.Json,
+            ageSeconds: result.Value.CacheMaxAgeSeconds,
+            eTag: result.Value.ETag,
+            cancellationToken: cancellationToken
+        );
+    }
+
     private static bool IsMatchingRequest(HttpContext context, [NotNullWhen(true)] out string? path)
     {
-        if (StringComparer.Ordinal.Equals(x: context.Request.Method, y: "GET") && context.Request.Path.HasValue && IsMatchingPath(context.Request.Path.Value))
+        if (
+            StringComparer.Ordinal.Equals(x: context.Request.Method, y: "GET")
+            && context.Request.Path.HasValue
+            && IsMatchingPath(context.Request.Path.Value)
+        )
         {
             path = context.Request.Path.Value;
 
@@ -117,28 +155,67 @@ public sealed class JsonMiddleware : IMiddleware
 
     private static bool IsMatchingPath(string path)
     {
-        return path.EndsWith(value: ".json", comparisonType: StringComparison.OrdinalIgnoreCase) || WhiteListedPaths.Contains(value: path, comparer: StringComparer.OrdinalIgnoreCase);
+        return path.EndsWith(value: ".json", comparisonType: StringComparison.OrdinalIgnoreCase)
+            || WhiteListedPaths.Contains(value: path, comparer: StringComparer.OrdinalIgnoreCase);
     }
 
-    private async ValueTask SuccessAsync(HttpContext context, string json, int ageSeconds, string eTag, CancellationToken cancellationToken)
+    private async ValueTask SuccessAsync(
+        HttpContext context,
+        string json,
+        int ageSeconds,
+        string eTag,
+        CancellationToken cancellationToken
+    )
     {
+        string quotedETag = EnsureQuoted(eTag);
+
+        if (
+            EntityTagHeaderValue.TryParse(input: quotedETag, parsedValue: out EntityTagHeaderValue? responseETag)
+            && IsNotModified(context: context, eTag: responseETag)
+        )
+        {
+            this.NotModified(context: context, ageSeconds: ageSeconds, eTag: quotedETag);
+
+            return;
+        }
+
         context.Response.StatusCode = (int)HttpStatusCode.OK;
         context.Response.Headers.Append(key: "Content-Type", value: "application/json; charset=utf-8");
         context.Response.Headers.CacheControl = $"public, must-revalidate, max-age={ageSeconds}";
-        context.Response.Headers.Expires = this._currentTimeSource.UtcNow()
-                                               .AddSeconds(ageSeconds)
-                                               .ToString(format: "ddd, dd MMM yyyy HH:mm:ss 'GMT'", formatProvider: CultureInfo.InvariantCulture);
-        context.Response.Headers.Append(key:"ETag", value: EnsureQuoted(eTag));
+        context.Response.Headers.Expires = this
+            ._currentTimeSource.UtcNow()
+            .AddSeconds(ageSeconds)
+            .ToString(format: "ddd, dd MMM yyyy HH:mm:ss 'GMT'", formatProvider: CultureInfo.InvariantCulture);
+        context.Response.Headers.Append(key: "ETag", value: quotedETag);
 
         await context.Response.WriteAsync(text: json, cancellationToken: cancellationToken);
     }
 
-        private static string EnsureQuoted(string source)
-        {
-            return source.StartsWith('"') && source.EndsWith('"')
-                ? source
-                : "\"" + source + "\"";
-        }
+    private static bool IsNotModified(HttpContext context, EntityTagHeaderValue eTag)
+    {
+        IList<EntityTagHeaderValue> ifNoneMatch = context.Request.GetTypedHeaders().IfNoneMatch;
+
+        return ifNoneMatch.Any(candidate =>
+            ReferenceEquals(objA: candidate, objB: EntityTagHeaderValue.Any)
+            || candidate.Compare(other: eTag, useStrongComparison: false)
+        );
+    }
+
+    private void NotModified(HttpContext context, int ageSeconds, string eTag)
+    {
+        context.Response.StatusCode = (int)HttpStatusCode.NotModified;
+        context.Response.Headers.CacheControl = $"public, must-revalidate, max-age={ageSeconds}";
+        context.Response.Headers.Expires = this
+            ._currentTimeSource.UtcNow()
+            .AddSeconds(ageSeconds)
+            .ToString(format: "ddd, dd MMM yyyy HH:mm:ss 'GMT'", formatProvider: CultureInfo.InvariantCulture);
+        context.Response.Headers.Append(key: "ETag", value: eTag);
+    }
+
+    private static string EnsureQuoted(string source)
+    {
+        return source.StartsWith('"') && source.EndsWith('"') ? source : "\"" + source + "\"";
+    }
 
     private static void Failed(HttpContext context, HttpStatusCode result)
     {
@@ -151,9 +228,10 @@ public sealed class JsonMiddleware : IMiddleware
         const int ageSeconds = 300;
         context.Response.StatusCode = (int)result;
         context.Response.Headers.CacheControl = $"public, must-revalidate, max-age={ageSeconds}";
-        context.Response.Headers.Expires = this._currentTimeSource.UtcNow()
-                                               .AddSeconds(ageSeconds)
-                                               .ToString(format: "ddd, dd MMM yyyy HH:mm:ss 'GMT'", formatProvider: CultureInfo.InvariantCulture);
+        context.Response.Headers.Expires = this
+            ._currentTimeSource.UtcNow()
+            .AddSeconds(ageSeconds)
+            .ToString(format: "ddd, dd MMM yyyy HH:mm:ss 'GMT'", formatProvider: CultureInfo.InvariantCulture);
     }
 
     private static void TooManyRequests(HttpContext context)

--- a/src/Credfeto.Nuget.Proxy.Server/credfeto-proxy.http
+++ b/src/Credfeto.Nuget.Proxy.Server/credfeto-proxy.http
@@ -20,6 +20,12 @@ Accept: application/json
 GET https://api.nuget.local:5555/v3/index.json
 Accept: application/json
 
-###  
+###
 GET {{credfeto_proxy_HostAddress}}/search/query?q=asyncfixer&skip=0&take=2147483647&prerelease=false&semVerLevel=2.0.0
 Accept: application/json
+
+###
+
+GET {{credfeto_proxy_HostAddress}}:/v3/index.json
+Accept: application/json
+If-None-Match: "replace-with-etag-from-previous-response"


### PR DESCRIPTION
## Summary

- Add an `If-None-Match` conditional check to `JsonMiddleware.InvokeAsync` so repeat metadata requests that already have the current ETag get a `304 Not Modified` instead of a full re-transformed body.
- This work is tracked from the implementation plan posted on the issue; the placeholder CHANGELOG entry here will be replaced with the real one once the code change lands.

## Test plan

- [ ] `InvokeAsync_Returns304_WhenIfNoneMatchMatchesETagAsync`
- [ ] `InvokeAsync_Returns304_WhenIfNoneMatchWeakMatchesStrongETagAsync`
- [ ] `InvokeAsync_Returns304_WhenIfNoneMatchIsWildcardAsync`
- [ ] `InvokeAsync_Returns200_WhenIfNoneMatchDoesNotMatchAsync`
- [ ] `InvokeAsync_Returns304_WithETagAndCacheControlHeadersAsync`

Closes #101