### PR TITLE
fix: Package cache path handling relies on a literal '../' substring check (path traversal hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Security
+- Harden package cache path handling against path traversal (#99)
 ### Added
 - Add X-Server response header middleware that appends the server hostname to every HTTP response
 - Enable trimmed publish for the service

--- a/src/Credfeto.Nuget.Proxy.Middleware/NuPkgMiddleware.cs
+++ b/src/Credfeto.Nuget.Proxy.Middleware/NuPkgMiddleware.cs
@@ -20,16 +20,6 @@ using Polly.Timeout;
 
 namespace Credfeto.Nuget.Proxy.Middleware;
 
-[SuppressMessage(
-    category: "Microsoft.Security",
-    checkId: "CA3003: Potential Path injection",
-    Justification = "Avoided by checking path above"
-)]
-[SuppressMessage(
-    category: "SecurityCodeScan.VS2019",
-    checkId: "SCS0018: Potential Path injection",
-    Justification = "Avoided by checking path above"
-)]
 public sealed class NuPkgMiddleware : IMiddleware
 {
     private readonly INupkgSource _nupkgSource;

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemJsonStorageTests.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemJsonStorageTests.cs
@@ -94,6 +94,35 @@ public sealed class FileSystemJsonStorageTests : LoggingFolderCleanupTestBase
     }
 
     [Fact]
+    public async Task SaveAndLoadRoundtripAsync_WhenFilenameContainsDoubleDotSubstring()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+        Uri requestUri = new("https://api.nuget.org/v3/foo..bar.json");
+
+        const string JSON_CONTENT = """{"version":"3.0.0"}""";
+        JsonMetadata metadata = new(
+            Etag: "\"abc123\"",
+            ContentLength: JSON_CONTENT.Length,
+            ContentType: "application/json"
+        );
+
+        await this._jsonStorage.SaveAsync(
+            requestUri: requestUri,
+            metadata: metadata,
+            jsonContent: JSON_CONTENT,
+            cancellationToken: cancellationToken
+        );
+
+        (JsonMetadata metadata, string content)? result = await this._jsonStorage.LoadAsync(
+            requestUri: requestUri,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: JSON_CONTENT, actual: result.Value.content);
+    }
+
+    [Fact]
     public async Task SaveAndLoadMetadataRoundtripAsync()
     {
         CancellationToken cancellationToken = this.CancellationToken();

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemPackageStorageTests.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemPackageStorageTests.cs
@@ -377,6 +377,35 @@ public sealed class FileSystemPackageStorageTests : LoggingFolderCleanupTestBase
         );
     }
 
+    [Fact]
+    public async Task SaveFileAndReadItBackAsync_WhenConfiguredPackagesPathHasTrailingSeparatorAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        string basePath = Path.Combine(path1: this.TempFolder, path2: "packages") + Path.DirectorySeparatorChar;
+
+        IPackageStorage storage = this.CreateStorage(basePath);
+
+        byte[] content = [1, 2, 3, 4, 5];
+
+        await using MemoryStream source = new(content);
+        await using Stream tee = await storage.SaveFileAsync(
+            sourcePath: "trailing-sep.nupkg",
+            content: source,
+            contentLength: content.Length,
+            cancellationToken: cancellationToken
+        );
+        await tee.CopyToAsync(Stream.Null, cancellationToken);
+
+        string? result = await storage.ReadFileAsync(
+            sourcePath: "trailing-sep.nupkg",
+            cancellationToken: cancellationToken
+        );
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: content, actual: await File.ReadAllBytesAsync(result, cancellationToken));
+    }
+
     private FileSystemPackageStorage CreateStorage(string basePath)
     {
         ProxyServerConfig config = new()

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemPackageStorageTests.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemPackageStorageTests.cs
@@ -84,6 +84,28 @@ public sealed class FileSystemPackageStorageTests : LoggingFolderCleanupTestBase
     }
 
     [Fact]
+    public async Task SaveFileAndReadItBackAsync_WhenFilenameContainsDoubleDotSubstring()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        byte[] content = [1, 2, 3, 4, 5];
+
+        await this.SaveAndDrainAsync(
+            sourcePath: "pkg/foo..bar.nupkg",
+            content: content,
+            cancellationToken: cancellationToken
+        );
+
+        string? result = await this._packageStorage.ReadFileAsync(
+            sourcePath: "pkg/foo..bar.nupkg",
+            cancellationToken: cancellationToken
+        );
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: content, actual: await File.ReadAllBytesAsync(result, cancellationToken));
+    }
+
+    [Fact]
     public async Task ReadFileAsync_WhenFileIsUnreadable_ReturnsNullAsync()
     {
         if (!OperatingSystem.IsLinux())
@@ -259,6 +281,88 @@ public sealed class FileSystemPackageStorageTests : LoggingFolderCleanupTestBase
 
         Assert.NotNull(result);
         Assert.Equal(expected: original, actual: await File.ReadAllBytesAsync(result, cancellationToken));
+    }
+
+    [Theory]
+    [InlineData("../escape.nupkg")]
+    [InlineData("..\\escape.nupkg")]
+    [InlineData("valid/../../escape.nupkg")]
+    public async Task ReadFileAsync_WhenPathTraversal_ReturnsNullAsync(string sourcePath)
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        string basePath = Path.Combine(path1: this.TempFolder, path2: "packages");
+        string escapeFile = Path.Combine(path1: this.TempFolder, path2: "escape.nupkg");
+        await File.WriteAllTextAsync(path: escapeFile, contents: "outside", cancellationToken: cancellationToken);
+
+        IPackageStorage storage = this.CreateStorage(basePath);
+
+        string? result = await storage.ReadFileAsync(sourcePath: sourcePath, cancellationToken: cancellationToken);
+
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("../escape.nupkg")]
+    [InlineData("..\\escape.nupkg")]
+    [InlineData("valid/../../escape.nupkg")]
+    public async Task SaveFileAsync_WhenPathTraversal_DoesNotWriteOutsideBaseAsync(string sourcePath)
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        string basePath = Path.Combine(path1: this.TempFolder, path2: "packages");
+        string escapeFile = Path.Combine(path1: this.TempFolder, path2: "escape.nupkg");
+
+        IPackageStorage storage = this.CreateStorage(basePath);
+
+        await using MemoryStream source = new([1, 2, 3]);
+        await using Stream tee = await storage.SaveFileAsync(
+            sourcePath: sourcePath,
+            content: source,
+            contentLength: 3,
+            cancellationToken: cancellationToken
+        );
+        await tee.CopyToAsync(Stream.Null, cancellationToken);
+
+        Assert.False(condition: File.Exists(escapeFile), userMessage: "Traversal write must not escape the base path");
+    }
+
+    [Fact]
+    public async Task SaveFileAsync_WhenPathResolvesToPrefixCollisionSibling_DoesNotWriteOutsideBaseAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        string basePath = Path.Combine(path1: this.TempFolder, path2: "packages");
+        string siblingFile = Path.Combine(path1: this.TempFolder, path2: "packages-evil", path3: "x.nupkg");
+
+        IPackageStorage storage = this.CreateStorage(basePath);
+
+        await using MemoryStream source = new([1, 2, 3]);
+        await using Stream tee = await storage.SaveFileAsync(
+            sourcePath: "../packages-evil/x.nupkg",
+            content: source,
+            contentLength: 3,
+            cancellationToken: cancellationToken
+        );
+        await tee.CopyToAsync(Stream.Null, cancellationToken);
+
+        Assert.False(
+            condition: File.Exists(siblingFile),
+            userMessage: "Prefix-collision sibling directory must not be treated as contained"
+        );
+    }
+
+    private FileSystemPackageStorage CreateStorage(string basePath)
+    {
+        ProxyServerConfig config = new()
+        {
+            UpstreamUrls = ["https://upstream.example.org"],
+            PublicUrl = "https://nuget.example.org",
+            Packages = basePath,
+            JsonMaxAgeSeconds = 60,
+        };
+
+        return new FileSystemPackageStorage(Options.Create(config), this.GetTypedLogger<FileSystemPackageStorage>());
     }
 
     private async Task SaveAndDrainAsync(string sourcePath, byte[] content, CancellationToken cancellationToken)

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemPackageStorageTests.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem.Tests/FileSystemPackageStorageTests.cs
@@ -328,6 +328,31 @@ public sealed class FileSystemPackageStorageTests : LoggingFolderCleanupTestBase
     }
 
     [Fact]
+    public async Task ReadFileAsync_WhenPathContainsNullCharacter_ReturnsNullAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        string? result = await this._packageStorage.ReadFileAsync(
+            sourcePath: "foo\0bar.nupkg",
+            cancellationToken: cancellationToken
+        );
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public Task SaveFileAsync_WhenPathContainsNullCharacter_DoesNotThrowAsync()
+    {
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        return this.SaveAndDrainAsync(
+            sourcePath: "foo\0bar.nupkg",
+            content: [1, 2, 3],
+            cancellationToken: cancellationToken
+        );
+    }
+
+    [Fact]
     public async Task SaveFileAsync_WhenPathResolvesToPrefixCollisionSibling_DoesNotWriteOutsideBaseAsync()
     {
         CancellationToken cancellationToken = this.CancellationToken();

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
@@ -31,8 +31,7 @@ public sealed class FileSystemJsonStorage : IJsonStorage
     {
         this._logger = logger;
 
-        this._basePath = Path.GetFullPath(config.Value.Metadata);
-        this._basePathWithSeparator = this._basePath + Path.DirectorySeparatorChar;
+        (this._basePath, this._basePathWithSeparator) = PathContainment.CreateBase(config.Value.Metadata);
 
         this.EnsureDirectoryExists(this._basePath);
     }
@@ -44,17 +43,17 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         CancellationToken cancellationToken
     )
     {
-        (string filename, string dir)? built = this.BuildJsonPath(
-            sourceHost: requestUri.Host,
-            path: requestUri.AbsolutePath
-        );
-
-        if (built is null)
+        if (
+            !this.TryBuildJsonPath(
+                sourceHost: requestUri.Host,
+                path: requestUri.AbsolutePath,
+                filename: out string jsonPath,
+                dir: out string dir
+            )
+        )
         {
             return;
         }
-
-        (string jsonPath, string dir) = built.Value;
 
         await this.WriteFileAsync(
             jsonPath: jsonPath,
@@ -129,18 +128,20 @@ public sealed class FileSystemJsonStorage : IJsonStorage
 
     public ValueTask<JsonMetadata?> LoadMetadataAsync(Uri requestUri, CancellationToken cancellationToken)
     {
-        (string filename, string dir)? built = this.BuildJsonPath(
-            sourceHost: requestUri.Host,
-            path: requestUri.AbsolutePath
-        );
-
-        if (built is null)
+        if (
+            !this.TryBuildJsonPath(
+                sourceHost: requestUri.Host,
+                path: requestUri.AbsolutePath,
+                filename: out string jsonPath,
+                dir: out _
+            )
+        )
         {
             return ValueTask.FromResult<JsonMetadata?>(null);
         }
 
         return this.ReadFromCacheAsync(
-            jsonPath: built.Value.filename,
+            jsonPath: jsonPath,
             readAsync: ReadMetadataFromFileAsync,
             cancellationToken: cancellationToken
         );
@@ -151,18 +152,20 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         CancellationToken cancellationToken
     )
     {
-        (string filename, string dir)? built = this.BuildJsonPath(
-            sourceHost: requestUri.Host,
-            path: requestUri.AbsolutePath
-        );
-
-        if (built is null)
+        if (
+            !this.TryBuildJsonPath(
+                sourceHost: requestUri.Host,
+                path: requestUri.AbsolutePath,
+                filename: out string jsonPath,
+                dir: out _
+            )
+        )
         {
             return ValueTask.FromResult<(JsonMetadata metadata, string content)?>(null);
         }
 
         return this.ReadFromCacheAsync(
-            jsonPath: built.Value.filename,
+            jsonPath: jsonPath,
             readAsync: ReadFromFileAsync,
             cancellationToken: cancellationToken
         );
@@ -354,25 +357,15 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         }
     }
 
-    private (string filename, string dir)? BuildJsonPath(string sourceHost, string path)
+    private bool TryBuildJsonPath(string sourceHost, string path, out string filename, out string dir)
     {
-        if (PathContainment.ContainsTraversalSegment(sourceHost) || PathContainment.ContainsTraversalSegment(path))
-        {
-            return null;
-        }
-
-        string? f = PathContainment.ResolveWithinBase(
+        return PathContainment.TryBuildContainedPath(
+            basePath: this._basePath,
             basePathWithSeparator: this._basePathWithSeparator,
-            combinedPath: Path.Combine(path1: this._basePath, path2: sourceHost, path.TrimStart('/'))
+            segments: [sourceHost, path],
+            filename: out filename,
+            dir: out dir
         );
-
-        if (f is null)
-        {
-            return null;
-        }
-
-        // ! Path under _basePathWithSeparator always produces a path with a directory component
-        return (f, Path.GetDirectoryName(f)!);
     }
 
     private void EnsureDirectoryExists(string folder)

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
@@ -24,13 +24,15 @@ public sealed class FileSystemJsonStorage : IJsonStorage
     private const int HeaderSize = 4 + 1 + 4;
 
     private readonly string _basePath;
+    private readonly string _basePathWithSeparator;
     private readonly ILogger<FileSystemJsonStorage> _logger;
 
     public FileSystemJsonStorage(IOptions<ProxyServerConfig> config, ILogger<FileSystemJsonStorage> logger)
     {
         this._logger = logger;
 
-        this._basePath = config.Value.Metadata;
+        this._basePath = Path.GetFullPath(config.Value.Metadata);
+        this._basePathWithSeparator = this._basePath + Path.DirectorySeparatorChar;
 
         this.EnsureDirectoryExists(this._basePath);
     }
@@ -42,8 +44,35 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         CancellationToken cancellationToken
     )
     {
-        (string jsonPath, string dir) = this.BuildJsonPath(sourceHost: requestUri.Host, path: requestUri.AbsolutePath);
+        (string filename, string dir)? built = this.BuildJsonPath(
+            sourceHost: requestUri.Host,
+            path: requestUri.AbsolutePath
+        );
 
+        if (built is null)
+        {
+            return;
+        }
+
+        (string jsonPath, string dir) = built.Value;
+
+        await this.WriteFileAsync(
+            jsonPath: jsonPath,
+            dir: dir,
+            metadata: metadata,
+            jsonContent: jsonContent,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    private async ValueTask WriteFileAsync(
+        string jsonPath,
+        string dir,
+        JsonMetadata metadata,
+        string jsonContent,
+        CancellationToken cancellationToken
+    )
+    {
         string? tempPath = null;
 
         try
@@ -100,10 +129,18 @@ public sealed class FileSystemJsonStorage : IJsonStorage
 
     public ValueTask<JsonMetadata?> LoadMetadataAsync(Uri requestUri, CancellationToken cancellationToken)
     {
-        (string jsonPath, _) = this.BuildJsonPath(sourceHost: requestUri.Host, path: requestUri.AbsolutePath);
+        (string filename, string dir)? built = this.BuildJsonPath(
+            sourceHost: requestUri.Host,
+            path: requestUri.AbsolutePath
+        );
+
+        if (built is null)
+        {
+            return ValueTask.FromResult<JsonMetadata?>(null);
+        }
 
         return this.ReadFromCacheAsync(
-            jsonPath: jsonPath,
+            jsonPath: built.Value.filename,
             readAsync: ReadMetadataFromFileAsync,
             cancellationToken: cancellationToken
         );
@@ -114,10 +151,18 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         CancellationToken cancellationToken
     )
     {
-        (string jsonPath, _) = this.BuildJsonPath(sourceHost: requestUri.Host, path: requestUri.AbsolutePath);
+        (string filename, string dir)? built = this.BuildJsonPath(
+            sourceHost: requestUri.Host,
+            path: requestUri.AbsolutePath
+        );
+
+        if (built is null)
+        {
+            return ValueTask.FromResult<(JsonMetadata metadata, string content)?>(null);
+        }
 
         return this.ReadFromCacheAsync(
-            jsonPath: jsonPath,
+            jsonPath: built.Value.filename,
             readAsync: ReadFromFileAsync,
             cancellationToken: cancellationToken
         );
@@ -309,11 +354,24 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         }
     }
 
-    private (string filename, string dir) BuildJsonPath(string sourceHost, string path)
+    private (string filename, string dir)? BuildJsonPath(string sourceHost, string path)
     {
-        string f = Path.Combine(path1: this._basePath, path2: sourceHost, path.TrimStart('/'));
+        if (PathContainment.ContainsTraversalSegment(sourceHost) || PathContainment.ContainsTraversalSegment(path))
+        {
+            return null;
+        }
 
-        // ! Path.Combine with an absolute basePath always produces a path with a directory component
+        string? f = PathContainment.ResolveWithinBase(
+            basePathWithSeparator: this._basePathWithSeparator,
+            combinedPath: Path.Combine(path1: this._basePath, path2: sourceHost, path.TrimStart('/'))
+        );
+
+        if (f is null)
+        {
+            return null;
+        }
+
+        // ! Path under _basePathWithSeparator always produces a path with a directory component
         return (f, Path.GetDirectoryName(f)!);
     }
 

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemJsonStorage.cs
@@ -362,7 +362,8 @@ public sealed class FileSystemJsonStorage : IJsonStorage
         return PathContainment.TryBuildContainedPath(
             basePath: this._basePath,
             basePathWithSeparator: this._basePathWithSeparator,
-            segments: [sourceHost, path],
+            segment1: sourceHost,
+            segment2: path,
             filename: out filename,
             dir: out dir
         );

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemPackageStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemPackageStorage.cs
@@ -15,19 +15,28 @@ public sealed class FileSystemPackageStorage : IPackageStorage
 {
     private readonly ILogger<FileSystemPackageStorage> _logger;
     private readonly string _basePath;
+    private readonly string _basePathWithSeparator;
 
     public FileSystemPackageStorage(IOptions<ProxyServerConfig> config, ILogger<FileSystemPackageStorage> logger)
     {
         this._logger = logger;
 
-        this._basePath = config.Value.Packages;
+        this._basePath = Path.GetFullPath(config.Value.Packages);
+        this._basePathWithSeparator = this._basePath + Path.DirectorySeparatorChar;
 
         this.EnsureDirectoryExists(this._basePath);
     }
 
     public async ValueTask<string?> ReadFileAsync(string sourcePath, CancellationToken cancellationToken)
     {
-        (string packagePath, _) = this.BuildPackagePath(path: sourcePath);
+        (string filename, string dir)? built = this.BuildPackagePath(path: sourcePath);
+
+        if (built is null)
+        {
+            return null;
+        }
+
+        string packagePath = built.Value.filename;
 
         try
         {
@@ -80,7 +89,14 @@ public sealed class FileSystemPackageStorage : IPackageStorage
         CancellationToken cancellationToken
     )
     {
-        (string packagePath, string dir) = this.BuildPackagePath(path: sourcePath);
+        (string filename, string dir)? built = this.BuildPackagePath(path: sourcePath);
+
+        if (built is null)
+        {
+            return ValueTask.FromResult(content);
+        }
+
+        (string packagePath, string dir) = built.Value;
 
         try
         {
@@ -129,11 +145,24 @@ public sealed class FileSystemPackageStorage : IPackageStorage
         }
     }
 
-    private (string filename, string dir) BuildPackagePath(string path)
+    private (string filename, string dir)? BuildPackagePath(string path)
     {
-        string f = Path.Combine(path1: this._basePath, path.TrimStart('/'));
+        if (PathContainment.ContainsTraversalSegment(path))
+        {
+            return null;
+        }
 
-        // ! Path.Combine with an absolute basePath always produces a path with a directory component
+        string? f = PathContainment.ResolveWithinBase(
+            basePathWithSeparator: this._basePathWithSeparator,
+            combinedPath: Path.Combine(path1: this._basePath, path.TrimStart('/'))
+        );
+
+        if (f is null)
+        {
+            return null;
+        }
+
+        // ! Path under _basePathWithSeparator always produces a path with a directory component
         return (f, Path.GetDirectoryName(f)!);
     }
 }

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemPackageStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemPackageStorage.cs
@@ -141,7 +141,7 @@ public sealed class FileSystemPackageStorage : IPackageStorage
         return PathContainment.TryBuildContainedPath(
             basePath: this._basePath,
             basePathWithSeparator: this._basePathWithSeparator,
-            segments: [path],
+            segment: path,
             filename: out filename,
             dir: out dir
         );

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemPackageStorage.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/FileSystemPackageStorage.cs
@@ -21,22 +21,17 @@ public sealed class FileSystemPackageStorage : IPackageStorage
     {
         this._logger = logger;
 
-        this._basePath = Path.GetFullPath(config.Value.Packages);
-        this._basePathWithSeparator = this._basePath + Path.DirectorySeparatorChar;
+        (this._basePath, this._basePathWithSeparator) = PathContainment.CreateBase(config.Value.Packages);
 
         this.EnsureDirectoryExists(this._basePath);
     }
 
     public async ValueTask<string?> ReadFileAsync(string sourcePath, CancellationToken cancellationToken)
     {
-        (string filename, string dir)? built = this.BuildPackagePath(path: sourcePath);
-
-        if (built is null)
+        if (!this.TryBuildPackagePath(path: sourcePath, filename: out string packagePath, dir: out _))
         {
             return null;
         }
-
-        string packagePath = built.Value.filename;
 
         try
         {
@@ -89,14 +84,10 @@ public sealed class FileSystemPackageStorage : IPackageStorage
         CancellationToken cancellationToken
     )
     {
-        (string filename, string dir)? built = this.BuildPackagePath(path: sourcePath);
-
-        if (built is null)
+        if (!this.TryBuildPackagePath(path: sourcePath, filename: out string packagePath, dir: out string dir))
         {
             return ValueTask.FromResult(content);
         }
-
-        (string packagePath, string dir) = built.Value;
 
         try
         {
@@ -145,24 +136,14 @@ public sealed class FileSystemPackageStorage : IPackageStorage
         }
     }
 
-    private (string filename, string dir)? BuildPackagePath(string path)
+    private bool TryBuildPackagePath(string path, out string filename, out string dir)
     {
-        if (PathContainment.ContainsTraversalSegment(path))
-        {
-            return null;
-        }
-
-        string? f = PathContainment.ResolveWithinBase(
+        return PathContainment.TryBuildContainedPath(
+            basePath: this._basePath,
             basePathWithSeparator: this._basePathWithSeparator,
-            combinedPath: Path.Combine(path1: this._basePath, path.TrimStart('/'))
+            segments: [path],
+            filename: out filename,
+            dir: out dir
         );
-
-        if (f is null)
-        {
-            return null;
-        }
-
-        // ! Path under _basePathWithSeparator always produces a path with a directory component
-        return (f, Path.GetDirectoryName(f)!);
     }
 }

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/PathContainment.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/PathContainment.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Credfeto.Nuget.Proxy.Package.Storage.FileSystem;
+
+internal static class PathContainment
+{
+    public static bool ContainsTraversalSegment(string path)
+    {
+        if (path.Contains(value: '\\', comparisonType: StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return path.Split('/')
+            .Any(segment => string.Equals(a: segment, b: "..", comparisonType: StringComparison.Ordinal));
+    }
+
+    public static string? ResolveWithinBase(string basePathWithSeparator, string combinedPath)
+    {
+        string full = Path.GetFullPath(combinedPath);
+
+        return full.StartsWith(basePathWithSeparator, StringComparison.Ordinal) ? full : null;
+    }
+}

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/PathContainment.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/PathContainment.cs
@@ -16,12 +16,12 @@ internal static class PathContainment
     public static bool TryBuildContainedPath(
         string basePath,
         string basePathWithSeparator,
-        string[] segments,
+        string segment,
         out string filename,
         out string dir
     )
     {
-        if (segments.Any(ContainsTraversalSegment))
+        if (ContainsTraversalSegment(segment))
         {
             filename = string.Empty;
             dir = string.Empty;
@@ -29,16 +29,35 @@ internal static class PathContainment
             return false;
         }
 
-        string[] combineParts = new string[segments.Length + 1];
-        combineParts[0] = basePath;
+        string full = Path.GetFullPath(Path.Combine(basePath, segment.TrimStart('/')));
 
-        for (int i = 0; i < segments.Length; ++i)
+        return TryFinish(full: full, basePathWithSeparator: basePathWithSeparator, filename: out filename, dir: out dir);
+    }
+
+    public static bool TryBuildContainedPath(
+        string basePath,
+        string basePathWithSeparator,
+        string segment1,
+        string segment2,
+        out string filename,
+        out string dir
+    )
+    {
+        if (ContainsTraversalSegment(segment1) || ContainsTraversalSegment(segment2))
         {
-            combineParts[i + 1] = segments[i].TrimStart('/');
+            filename = string.Empty;
+            dir = string.Empty;
+
+            return false;
         }
 
-        string full = Path.GetFullPath(Path.Combine(combineParts));
+        string full = Path.GetFullPath(Path.Combine(basePath, segment1.TrimStart('/'), segment2.TrimStart('/')));
 
+        return TryFinish(full: full, basePathWithSeparator: basePathWithSeparator, filename: out filename, dir: out dir);
+    }
+
+    private static bool TryFinish(string full, string basePathWithSeparator, out string filename, out string dir)
+    {
         if (!full.StartsWith(basePathWithSeparator, StringComparison.Ordinal))
         {
             filename = string.Empty;

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/PathContainment.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/PathContainment.cs
@@ -8,7 +8,10 @@ internal static class PathContainment
 {
     public static (string basePath, string basePathWithSeparator) CreateBase(string configuredPath)
     {
-        string basePath = Path.GetFullPath(configuredPath);
+        // Path.GetFullPath preserves a trailing separator if one was configured; trim it so
+        // basePathWithSeparator below doesn't end up doubled (which would make every built path
+        // fail the TryFinish containment check, rejecting all reads/writes).
+        string basePath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(configuredPath));
 
         return (basePath, basePath + Path.DirectorySeparatorChar);
     }

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/PathContainment.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/PathContainment.cs
@@ -6,7 +6,56 @@ namespace Credfeto.Nuget.Proxy.Package.Storage.FileSystem;
 
 internal static class PathContainment
 {
-    public static bool ContainsTraversalSegment(string path)
+    public static (string basePath, string basePathWithSeparator) CreateBase(string configuredPath)
+    {
+        string basePath = Path.GetFullPath(configuredPath);
+
+        return (basePath, basePath + Path.DirectorySeparatorChar);
+    }
+
+    public static bool TryBuildContainedPath(
+        string basePath,
+        string basePathWithSeparator,
+        string[] segments,
+        out string filename,
+        out string dir
+    )
+    {
+        if (segments.Any(ContainsTraversalSegment))
+        {
+            filename = string.Empty;
+            dir = string.Empty;
+
+            return false;
+        }
+
+        string[] combineParts = new string[segments.Length + 1];
+        combineParts[0] = basePath;
+
+        for (int i = 0; i < segments.Length; ++i)
+        {
+            combineParts[i + 1] = segments[i].TrimStart('/');
+        }
+
+        string full = Path.GetFullPath(Path.Combine(combineParts));
+
+        if (!full.StartsWith(basePathWithSeparator, StringComparison.Ordinal))
+        {
+            filename = string.Empty;
+            dir = string.Empty;
+
+            return false;
+        }
+
+        filename = full;
+
+        // ! Path under basePathWithSeparator always produces a path with a directory component
+        dir = Path.GetDirectoryName(full)!;
+
+        return true;
+    }
+
+    private static bool ContainsTraversalSegment(string path)
     {
         if (path.Contains(value: '\\', comparisonType: StringComparison.Ordinal))
         {
@@ -15,12 +64,5 @@ internal static class PathContainment
 
         return path.Split('/')
             .Any(segment => string.Equals(a: segment, b: "..", comparisonType: StringComparison.Ordinal));
-    }
-
-    public static string? ResolveWithinBase(string basePathWithSeparator, string combinedPath)
-    {
-        string full = Path.GetFullPath(combinedPath);
-
-        return full.StartsWith(basePathWithSeparator, StringComparison.Ordinal) ? full : null;
     }
 }

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/PathContainment.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/PathContainment.cs
@@ -26,7 +26,10 @@ internal static class PathContainment
             return Fail(filename: out filename, dir: out dir);
         }
 
-        string full = Path.GetFullPath(Path.Combine(basePath, segment.TrimStart('/')));
+        if (!TryGetFullPath(Path.Combine(basePath, segment.TrimStart('/')), out string full))
+        {
+            return Fail(filename: out filename, dir: out dir);
+        }
 
         return TryFinish(full: full, basePathWithSeparator: basePathWithSeparator, filename: out filename, dir: out dir);
     }
@@ -45,9 +48,36 @@ internal static class PathContainment
             return Fail(filename: out filename, dir: out dir);
         }
 
-        string full = Path.GetFullPath(Path.Combine(basePath, segment1.TrimStart('/'), segment2.TrimStart('/')));
+        if (
+            !TryGetFullPath(
+                Path.Combine(basePath, segment1.TrimStart('/'), segment2.TrimStart('/')),
+                out string full
+            )
+        )
+        {
+            return Fail(filename: out filename, dir: out dir);
+        }
 
         return TryFinish(full: full, basePathWithSeparator: basePathWithSeparator, filename: out filename, dir: out dir);
+    }
+
+    // Path.GetFullPath throws ArgumentException for inputs it cannot canonicalise (e.g. an
+    // embedded NUL character); treat that the same as any other rejected segment instead of
+    // letting it propagate as an unhandled exception out of the storage layer.
+    private static bool TryGetFullPath(string combined, out string full)
+    {
+        try
+        {
+            full = Path.GetFullPath(combined);
+
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            full = string.Empty;
+
+            return false;
+        }
     }
 
     private static bool TryFinish(string full, string basePathWithSeparator, out string filename, out string dir)

--- a/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/PathContainment.cs
+++ b/src/Credfeto.Nuget.Proxy.Package.Storage.FileSystem/PathContainment.cs
@@ -23,10 +23,7 @@ internal static class PathContainment
     {
         if (ContainsTraversalSegment(segment))
         {
-            filename = string.Empty;
-            dir = string.Empty;
-
-            return false;
+            return Fail(filename: out filename, dir: out dir);
         }
 
         string full = Path.GetFullPath(Path.Combine(basePath, segment.TrimStart('/')));
@@ -45,10 +42,7 @@ internal static class PathContainment
     {
         if (ContainsTraversalSegment(segment1) || ContainsTraversalSegment(segment2))
         {
-            filename = string.Empty;
-            dir = string.Empty;
-
-            return false;
+            return Fail(filename: out filename, dir: out dir);
         }
 
         string full = Path.GetFullPath(Path.Combine(basePath, segment1.TrimStart('/'), segment2.TrimStart('/')));
@@ -60,10 +54,7 @@ internal static class PathContainment
     {
         if (!full.StartsWith(basePathWithSeparator, StringComparison.Ordinal))
         {
-            filename = string.Empty;
-            dir = string.Empty;
-
-            return false;
+            return Fail(filename: out filename, dir: out dir);
         }
 
         filename = full;
@@ -74,6 +65,17 @@ internal static class PathContainment
         return true;
     }
 
+    private static bool Fail(out string filename, out string dir)
+    {
+        filename = string.Empty;
+        dir = string.Empty;
+
+        return false;
+    }
+
+    // Defense-in-depth only: Path.GetFullPath + the base-path prefix check in TryFinish is the
+    // actual containment boundary and already rejects any real escape (including prefix-collision
+    // siblings). This rejects obviously-malicious segments up front.
     private static bool ContainsTraversalSegment(string path)
     {
         if (path.Contains(value: '\\', comparisonType: StringComparison.Ordinal))


### PR DESCRIPTION
## Summary

Hardens the package cache's path handling against traversal:

- `FileSystemPackageStorage.BuildPackagePath` and `FileSystemJsonStorage.BuildJsonPath` will canonicalise the constructed path with `Path.GetFullPath` and verify it stays strictly under the configured base directory, rejecting backslash segments and `..` path segments explicitly.
- `NuPkgMiddleware`'s CA3003/SCS0018 suppressions will be removed or narrowed now that the real guard lives in the storage layer, rather than relying solely on the `../` substring check.
- Adds path-traversal regression tests (forward-slash, backslash, multi-hop, prefix-collision) for both storage classes.

See the approved implementation plan in #99 for full details.

Closes #99